### PR TITLE
feat: add cosign verification artifacts to OCI layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ cargo run -p ai-catalog-cli -- trust inspect --json fixtures/spec-example.json
 cargo run -p ai-catalog-cli -- oci pack fixtures/spec-example.json
 cargo run -p ai-catalog-cli -- oci unpack artifacts.json
 cargo run -p ai-catalog-cli -- oci export-layout fixtures/spec-example.json /tmp/ai-catalog-layout
+cargo run -p ai-catalog-cli -- oci export-layout --cosign-key cosign.key fixtures/spec-example.json /tmp/ai-catalog-layout
 cargo run -p ai-catalog-cli -- oci unpack-layout /tmp/ai-catalog-layout
 cargo run -p ai-catalog-cli -- oci push fixtures/spec-example.json ghcr.io/example/ai-catalog:latest
+cargo run -p ai-catalog-cli -- oci push --cosign-key cosign.key fixtures/spec-example.json ghcr.io/example/ai-catalog:latest
 cargo run -p ai-catalog-cli -- oci push fixtures/spec-example.json example.com:latest --to-oci-layout-path /tmp/ai-catalog-copy
 cat fixtures/spec-example.json | cargo run -p ai-catalog-cli -- validate --json -
 cat fixtures/spec-example.json | cargo run -p ai-catalog-cli -- format -
@@ -62,6 +64,12 @@ the Rust library. `oci export-layout` writes a standard OCI image layout directo
 `oci unpack-layout` imports that standard layout back into AI Catalog JSON, and
 `oci push` delegates distribution to `oras cp -r` from a temporary exported layout
 so standard OCI tooling can validate or publish the result.
+
+When `--cosign-key` is supplied to `oci export-layout` or `oci push`, the CLI
+canonicalizes each entry trust manifest, signs that blob with `cosign sign-blob`,
+derives or reads a PEM public key, and stores both the detached signature and
+public key as OCI referrer artifacts in the exported layout. If the private key
+is encrypted, provide the password non-interactively through `COSIGN_PASSWORD`.
 
 ## Demo
 

--- a/crates/ai-catalog-cli/Cargo.toml
+++ b/crates/ai-catalog-cli/Cargo.toml
@@ -14,4 +14,6 @@ ai-catalog = { path = "../ai-catalog" }
 ai-catalog-oci = { path = "../ai-catalog-oci" }
 ai-catalog-trust = { path = "../ai-catalog-trust" }
 ai-catalog-validate = { path = "../ai-catalog-validate" }
+serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true

--- a/crates/ai-catalog-cli/src/lib.rs
+++ b/crates/ai-catalog-cli/src/lib.rs
@@ -7,17 +7,23 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use ai_catalog::{parse_file, parse_reader, write_writer};
-use ai_catalog_oci::{OciArtifactSet, export_layout, import_layout, pack_catalog, unpack_catalog};
+use ai_catalog::{AiCatalog, parse_file, parse_reader, write_writer};
+use ai_catalog_oci::{
+    OciArtifactSet, attach_cosign_verification_artifacts, export_layout, import_layout,
+    pack_catalog, unpack_catalog,
+};
 use ai_catalog_trust::{
     CatalogTrustReport, Finding as TrustFinding, ManifestReport, Severity, analyze_catalog,
+    canonicalize_trust_manifest,
 };
 use ai_catalog_validate::{ConformanceLevel, Diagnostic, validate};
 use serde_json::json;
+use sha2::{Digest as _, Sha256};
 
 const BIN_NAME: &str = "ai-catalog-cli";
 const DEFAULT_OCI_LAYOUT_TAG: &str = "latest";
 const ORAS_BIN_ENV: &str = "AI_CATALOG_ORAS_BIN";
+const COSIGN_BIN_ENV: &str = "AI_CATALOG_COSIGN_BIN";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OutputFormat {
@@ -42,6 +48,8 @@ struct OciExportLayoutOptions<'a> {
     path: &'a str,
     layout_path: &'a str,
     tag: &'a str,
+    cosign_key: Option<&'a str>,
+    cosign_public_key: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,6 +66,20 @@ struct OciPushOptions<'a> {
     to_oci_layout_path: Option<&'a str>,
     plain_http: bool,
     insecure: bool,
+    cosign_key: Option<&'a str>,
+    cosign_public_key: Option<&'a str>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CosignBlobBundle {
+    message_signature: CosignMessageSignature,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CosignMessageSignature {
+    signature: String,
 }
 
 pub fn run<I, S, R, W, E>(args: I, stdin: &mut R, stdout: &mut W, stderr: &mut E) -> io::Result<i32>
@@ -389,6 +411,27 @@ fn oci_export_layout_command<R: Read, W: Write, E: Write>(
         }
     };
 
+    let mut artifacts = artifacts;
+
+    if let Some(cosign_key) = options.cosign_key {
+        match attach_cosign_material(
+            &catalog,
+            &mut artifacts,
+            cosign_key,
+            options.cosign_public_key,
+        ) {
+            Ok(attached) => {
+                if attached > 0 {
+                    writeln!(stdout, "attached Cosign verification artifacts for {attached} trust manifest(s)")?;
+                }
+            }
+            Err(error) => {
+                writeln!(stderr, "failed to attach Cosign verification artifacts: {error}")?;
+                return Ok(1);
+            }
+        }
+    }
+
     match export_layout(&artifacts, options.layout_path, options.tag) {
         Ok(()) => {
             writeln!(
@@ -477,6 +520,27 @@ fn oci_push_command<R: Read, W: Write, E: Write>(
             return Ok(1);
         }
     };
+
+    let mut artifacts = artifacts;
+
+    if let Some(cosign_key) = options.cosign_key {
+        match attach_cosign_material(
+            &catalog,
+            &mut artifacts,
+            cosign_key,
+            options.cosign_public_key,
+        ) {
+            Ok(attached) => {
+                if attached > 0 {
+                    writeln!(stdout, "attached Cosign verification artifacts for {attached} trust manifest(s)")?;
+                }
+            }
+            Err(error) => {
+                writeln!(stderr, "failed to attach Cosign verification artifacts: {error}")?;
+                return Ok(1);
+            }
+        }
+    }
 
     let layout_dir = temporary_layout_dir("ai-catalog-oras-layout");
     let result = push_artifacts_via_oras(&artifacts, &layout_dir, options, stdout, stderr);
@@ -673,6 +737,8 @@ fn parse_oci_export_layout_options<'a>(
     stderr: &mut impl Write,
 ) -> io::Result<Option<OciExportLayoutOptions<'a>>> {
     let mut tag = DEFAULT_OCI_LAYOUT_TAG;
+    let mut cosign_key = None;
+    let mut cosign_public_key = None;
     let mut positional = Vec::new();
     let mut index = 0;
 
@@ -689,6 +755,28 @@ fn parse_oci_export_layout_options<'a>(
 
                 tag = value;
             }
+            "--cosign-key" => {
+                index += 1;
+
+                let Some(value) = args.get(index) else {
+                    writeln!(stderr, "oci export-layout requires a value for --cosign-key")?;
+                    write_usage(stderr)?;
+                    return Ok(None);
+                };
+
+                cosign_key = Some(value.as_str());
+            }
+            "--cosign-public-key" => {
+                index += 1;
+
+                let Some(value) = args.get(index) else {
+                    writeln!(stderr, "oci export-layout requires a value for --cosign-public-key")?;
+                    write_usage(stderr)?;
+                    return Ok(None);
+                };
+
+                cosign_public_key = Some(value.as_str());
+            }
             "-" => positional.push("-"),
             value if value.starts_with('-') => {
                 writeln!(stderr, "unknown oci export-layout option: {value}")?;
@@ -699,6 +787,15 @@ fn parse_oci_export_layout_options<'a>(
         }
 
         index += 1;
+    }
+
+    if cosign_public_key.is_some() && cosign_key.is_none() {
+        writeln!(
+            stderr,
+            "oci export-layout requires --cosign-key when --cosign-public-key is set"
+        )?;
+        write_usage(stderr)?;
+        return Ok(None);
     }
 
     if positional.len() != 2 {
@@ -714,6 +811,8 @@ fn parse_oci_export_layout_options<'a>(
         path: positional[0],
         layout_path: positional[1],
         tag,
+        cosign_key,
+        cosign_public_key,
     }))
 }
 
@@ -725,6 +824,8 @@ fn parse_oci_push_options<'a>(
     let mut to_oci_layout_path = None;
     let mut plain_http = false;
     let mut insecure = false;
+    let mut cosign_key = None;
+    let mut cosign_public_key = None;
     let mut positional = Vec::new();
     let mut index = 0;
 
@@ -740,6 +841,28 @@ fn parse_oci_push_options<'a>(
                 };
 
                 tag = value;
+            }
+            "--cosign-key" => {
+                index += 1;
+
+                let Some(value) = args.get(index) else {
+                    writeln!(stderr, "oci push requires a value for --cosign-key")?;
+                    write_usage(stderr)?;
+                    return Ok(None);
+                };
+
+                cosign_key = Some(value.as_str());
+            }
+            "--cosign-public-key" => {
+                index += 1;
+
+                let Some(value) = args.get(index) else {
+                    writeln!(stderr, "oci push requires a value for --cosign-public-key")?;
+                    write_usage(stderr)?;
+                    return Ok(None);
+                };
+
+                cosign_public_key = Some(value.as_str());
             }
             "--to-oci-layout-path" => {
                 index += 1;
@@ -766,6 +889,15 @@ fn parse_oci_push_options<'a>(
         index += 1;
     }
 
+    if cosign_public_key.is_some() && cosign_key.is_none() {
+        writeln!(
+            stderr,
+            "oci push requires --cosign-key when --cosign-public-key is set"
+        )?;
+        write_usage(stderr)?;
+        return Ok(None);
+    }
+
     if positional.len() != 2 {
         writeln!(
             stderr,
@@ -782,6 +914,8 @@ fn parse_oci_push_options<'a>(
         to_oci_layout_path,
         plain_http,
         insecure,
+        cosign_key,
+        cosign_public_key,
     }))
 }
 
@@ -870,7 +1004,7 @@ fn write_usage(writer: &mut impl Write) -> io::Result<()> {
     writeln!(writer, "  {BIN_NAME} oci unpack <path|->")?;
     writeln!(
         writer,
-        "  {BIN_NAME} oci export-layout [--tag <tag>] <path|-> <layout-dir>"
+        "  {BIN_NAME} oci export-layout [--tag <tag>] [--cosign-key <path>] [--cosign-public-key <path>] <path|-> <layout-dir>"
     )?;
     writeln!(
         writer,
@@ -878,7 +1012,7 @@ fn write_usage(writer: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         writer,
-        "  {BIN_NAME} oci push [--tag <tag>] [--plain-http] [--insecure] [--to-oci-layout-path <layout-dir>] <path|-> <target>"
+        "  {BIN_NAME} oci push [--tag <tag>] [--plain-http] [--insecure] [--to-oci-layout-path <layout-dir>] [--cosign-key <path>] [--cosign-public-key <path>] <path|-> <target>"
     )?;
     writeln!(writer, "  {BIN_NAME} help")?;
     writeln!(writer, "  {BIN_NAME} version")?;
@@ -969,6 +1103,151 @@ fn execute_oras(args: &[String]) -> io::Result<std::process::Output> {
     let oras_bin = std::env::var(ORAS_BIN_ENV).unwrap_or_else(|_| "oras".to_owned());
 
     Command::new(oras_bin).args(args).output()
+}
+
+fn attach_cosign_material(
+    catalog: &AiCatalog,
+    artifacts: &mut OciArtifactSet,
+    cosign_key: &str,
+    cosign_public_key: Option<&str>,
+) -> io::Result<usize> {
+    let targets = catalog
+        .entries
+        .iter()
+        .zip(artifacts.index.manifests.iter())
+        .filter_map(|(entry, descriptor)| {
+            entry
+                .trust_manifest
+                .clone()
+                .map(|trust_manifest| (descriptor.digest.clone(), trust_manifest))
+        })
+        .collect::<Vec<_>>();
+
+    if targets.is_empty() {
+        return Ok(0);
+    }
+
+    let public_key = load_cosign_public_key(cosign_key, cosign_public_key)?;
+
+    for (subject_digest, trust_manifest) in targets {
+        let canonical_manifest =
+            canonicalize_trust_manifest(&trust_manifest).map_err(io::Error::other)?;
+        let canonical_bytes = canonical_manifest.into_bytes();
+        let payload_digest = format!(
+            "sha256:{}",
+            digest_hex(Sha256::digest(&canonical_bytes).as_slice())
+        );
+        let signature = sign_blob_with_cosign(&canonical_bytes, cosign_key)?;
+
+        attach_cosign_verification_artifacts(
+            artifacts,
+            &subject_digest,
+            &trust_manifest.identity,
+            &payload_digest,
+            &signature,
+            &public_key,
+        )
+        .map_err(io::Error::other)?;
+    }
+
+    Ok(catalog
+        .entries
+        .iter()
+        .filter(|entry| entry.trust_manifest.is_some())
+        .count())
+}
+
+fn load_cosign_public_key(
+    cosign_key: &str,
+    cosign_public_key: Option<&str>,
+) -> io::Result<Vec<u8>> {
+    if let Some(path) = cosign_public_key {
+        return fs::read(path);
+    }
+
+    let args = build_cosign_public_key_args(cosign_key);
+    let output = execute_cosign(&args)?;
+
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(command_failure("cosign public-key", &output))
+    }
+}
+
+fn sign_blob_with_cosign(payload: &[u8], cosign_key: &str) -> io::Result<Vec<u8>> {
+    let work_dir = temporary_layout_dir("ai-catalog-cosign");
+    let payload_path = work_dir.join("trust-manifest.json");
+    let bundle_path = work_dir.join("trust-manifest.bundle.json");
+
+    fs::create_dir_all(&work_dir)?;
+    fs::write(&payload_path, payload)?;
+
+    let args = build_cosign_sign_blob_args(cosign_key, &payload_path, &bundle_path);
+    let output = execute_cosign(&args)?;
+    let result = if output.status.success() {
+        let bundle_bytes = fs::read(&bundle_path)?;
+        let bundle: CosignBlobBundle = serde_json::from_slice(&bundle_bytes).map_err(io::Error::other)?;
+
+        Ok(bundle.message_signature.signature.into_bytes())
+    } else {
+        Err(command_failure("cosign sign-blob", &output))
+    };
+
+    let _ = fs::remove_dir_all(&work_dir);
+    result
+}
+
+fn build_cosign_sign_blob_args(
+    cosign_key: &str,
+    payload_path: &Path,
+    bundle_path: &Path,
+) -> Vec<String> {
+    vec![
+        "sign-blob".to_owned(),
+        "--yes".to_owned(),
+        "--key".to_owned(),
+        cosign_key.to_owned(),
+        "--bundle".to_owned(),
+        bundle_path.display().to_string(),
+        payload_path.display().to_string(),
+    ]
+}
+
+fn build_cosign_public_key_args(cosign_key: &str) -> Vec<String> {
+    vec!["public-key".to_owned(), "--key".to_owned(), cosign_key.to_owned()]
+}
+
+fn execute_cosign(args: &[String]) -> io::Result<std::process::Output> {
+    let cosign_bin = std::env::var(COSIGN_BIN_ENV).unwrap_or_else(|_| "cosign".to_owned());
+
+    Command::new(cosign_bin).args(args).output()
+}
+
+fn command_failure(command: &str, output: &std::process::Output) -> io::Error {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let details = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("exited with status {}", output.status)
+    };
+
+    io::Error::other(format!("{command} failed: {details}"))
+}
+
+fn digest_hex(bytes: &[u8]) -> String {
+    let mut hex = String::with_capacity(bytes.len() * 2);
+
+    for byte in bytes {
+        use std::fmt::Write as _;
+
+        let _ = write!(&mut hex, "{byte:02x}");
+    }
+
+    hex
 }
 
 fn write_process_output(writer: &mut impl Write, bytes: &[u8]) -> io::Result<()> {
@@ -1190,13 +1469,21 @@ fn conformance_level_name(level: ConformanceLevel) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use ai_catalog_oci::{
+        COSIGN_PUBLIC_KEY_ARTIFACT_TYPE, COSIGN_SIGNATURE_ARTIFACT_TYPE,
+        TRUST_MANIFEST_ARTIFACT_TYPE, import_layout,
+    };
     use super::run;
 
     use serde_json::Value;
     use std::env;
     use std::fs;
+    use std::io::Write as _;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
 
     #[test]
     fn prints_help_without_arguments() {
@@ -1207,9 +1494,9 @@ mod tests {
         assert!(stdout.contains("validate [--json] <path|->"));
         assert!(stdout.contains("trust inspect [--json] <path|->"));
         assert!(stdout.contains("oci pack <path|->"));
-        assert!(stdout.contains("oci export-layout [--tag <tag>] <path|-> <layout-dir>"));
+        assert!(stdout.contains("oci export-layout [--tag <tag>] [--cosign-key <path>] [--cosign-public-key <path>] <path|-> <layout-dir>"));
         assert!(stdout.contains("oci unpack-layout [--ref-name <name>] <layout-dir>"));
-        assert!(stdout.contains("oci push [--tag <tag>] [--plain-http] [--insecure] [--to-oci-layout-path <layout-dir>] <path|-> <target>"));
+        assert!(stdout.contains("oci push [--tag <tag>] [--plain-http] [--insecure] [--to-oci-layout-path <layout-dir>] [--cosign-key <path>] [--cosign-public-key <path>] <path|-> <target>"));
         assert!(stderr.is_empty());
     }
 
@@ -1526,6 +1813,86 @@ mod tests {
     }
 
     #[test]
+    fn rejects_cosign_public_key_without_cosign_key() {
+        let layout_dir = unique_temp_dir("ai-catalog-cli-layout-cosign-option");
+        let (exit_code, stdout, stderr) = run_command(
+            [
+                "ai-catalog-cli",
+                "oci",
+                "export-layout",
+                "--cosign-public-key",
+                "cosign.pub",
+                "-",
+                layout_dir.to_str().expect("path should be utf-8"),
+            ],
+            &canonical_fixture_text(),
+        );
+
+        assert_eq!(exit_code, 2);
+        assert!(stdout.is_empty());
+        assert!(stderr.contains("requires --cosign-key when --cosign-public-key is set"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn oci_export_layout_with_cosign_writes_signature_and_key_referrers() {
+        let fixture = r#"{
+    "specVersion": "1.0",
+    "entries": [
+        {
+            "identifier": "urn:example:model",
+            "displayName": "Example Model",
+            "mediaType": "application/json",
+            "data": { "name": "example" },
+            "trustManifest": {
+                "identity": "urn:example:model"
+            }
+        }
+    ]
+}"#;
+        let layout_dir = unique_temp_dir("ai-catalog-cli-layout-cosign");
+        let tool_dir = unique_temp_dir("ai-catalog-cli-fake-cosign");
+
+        fs::create_dir_all(&tool_dir).expect("tool dir should exist");
+        let script_path = write_fake_cosign_script(&tool_dir);
+
+        let (exit_code, stdout, stderr) = with_env_var(super::COSIGN_BIN_ENV, script_path.as_os_str(), || {
+            run_command(
+                [
+                    "ai-catalog-cli",
+                    "oci",
+                    "export-layout",
+                    "--cosign-key",
+                    "fake.key",
+                    "--tag",
+                    "demo",
+                    "-",
+                    layout_dir.to_str().expect("path should be utf-8"),
+                ],
+                fixture,
+            )
+        });
+
+        assert_eq!(exit_code, 0);
+        assert!(stdout.contains("attached Cosign verification artifacts for 1 trust manifest(s)"));
+        assert!(stderr.is_empty());
+
+        let imported = import_layout(&layout_dir, Some("demo")).expect("layout should import");
+        let entry_digest = imported.index.manifests[0].digest.clone();
+        let referrer_types = imported.referrers[&entry_digest]
+            .iter()
+            .filter_map(|manifest| manifest.artifact_type.as_deref())
+            .collect::<Vec<_>>();
+
+        assert!(referrer_types.contains(&TRUST_MANIFEST_ARTIFACT_TYPE));
+        assert!(referrer_types.contains(&COSIGN_SIGNATURE_ARTIFACT_TYPE));
+        assert!(referrer_types.contains(&COSIGN_PUBLIC_KEY_ARTIFACT_TYPE));
+
+        fs::remove_dir_all(layout_dir).expect("layout dir should be removable");
+        fs::remove_dir_all(tool_dir).expect("tool dir should be removable");
+    }
+
+    #[test]
     fn oci_unpack_layout_round_trips_exported_layout() {
         let fixture = canonical_fixture_text();
         let layout_dir = unique_temp_dir("ai-catalog-cli-unpack-layout");
@@ -1619,6 +1986,35 @@ mod tests {
     }
 
     #[test]
+    fn builds_cosign_sign_blob_arguments() {
+        let args = super::build_cosign_sign_blob_args(
+            "cosign.key",
+            Path::new("/tmp/trust-manifest.json"),
+            Path::new("/tmp/trust-manifest.sig"),
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                "sign-blob",
+                "--yes",
+                "--key",
+                "cosign.key",
+                "--bundle",
+                "/tmp/trust-manifest.sig",
+                "/tmp/trust-manifest.json",
+            ]
+        );
+    }
+
+    #[test]
+    fn builds_cosign_public_key_arguments() {
+        let args = super::build_cosign_public_key_args("cosign.key");
+
+        assert_eq!(args, vec!["public-key", "--key", "cosign.key"]);
+    }
+
+    #[test]
     fn strips_tags_from_target_repositories() {
         assert_eq!(
             super::target_repository("example.com/catalog:demo"),
@@ -1668,5 +2064,52 @@ mod tests {
             String::from_utf8(stdout).expect("stdout should be utf-8"),
             String::from_utf8(stderr).expect("stderr should be utf-8"),
         )
+    }
+
+    fn with_env_var<T>(key: &str, value: &std::ffi::OsStr, f: impl FnOnce() -> T) -> T {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should be available");
+        let previous = env::var_os(key);
+        unsafe {
+            env::set_var(key, value);
+        }
+        let result = f();
+
+        if let Some(previous) = previous {
+            unsafe {
+                env::set_var(key, previous);
+            }
+        } else {
+            unsafe {
+                env::remove_var(key);
+            }
+        }
+
+        result
+    }
+
+    #[cfg(unix)]
+    fn write_fake_cosign_script(dir: &Path) -> PathBuf {
+        let script_path = dir.join("fake-cosign.sh");
+        let mut file = fs::File::create(&script_path).expect("script should be creatable");
+
+        write!(
+            file,
+            "{}",
+            "#!/bin/sh\nset -eu\ncmd=\"$1\"\nshift\ncase \"$cmd\" in\n  public-key)\n    echo '-----BEGIN PUBLIC KEY-----'\n    echo 'RkFLRUNPU0lHTlBVQkxJQ0tFWQ=='\n    echo '-----END PUBLIC KEY-----'\n    ;;\n  sign-blob)\n    bundle=''\n    while [ $# -gt 0 ]; do\n      case \"$1\" in\n        --bundle)\n          bundle=\"$2\"\n          shift 2\n          ;;\n        --key)\n          shift 2\n          ;;\n        --yes)\n          shift 1\n          ;;\n        *)\n          shift 1\n          ;;\n      esac\n    done\n    printf '{\"mediaType\":\"application/vnd.dev.sigstore.bundle.v0.3+json\",\"messageSignature\":{\"signature\":\"fake-cosign-signature\"}}' > \"$bundle\"\n    ;;\n  *)\n    echo \"unexpected cosign command: $cmd\" >&2\n    exit 1\n    ;;\nesac"
+        )
+        .expect("script should be writable");
+
+        let mut permissions = fs::metadata(&script_path)
+            .expect("script metadata should exist")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("script should be executable");
+
+        script_path
     }
 }

--- a/crates/ai-catalog-cli/src/lib.rs
+++ b/crates/ai-catalog-cli/src/lib.rs
@@ -422,11 +422,17 @@ fn oci_export_layout_command<R: Read, W: Write, E: Write>(
         ) {
             Ok(attached) => {
                 if attached > 0 {
-                    writeln!(stdout, "attached Cosign verification artifacts for {attached} trust manifest(s)")?;
+                    writeln!(
+                        stdout,
+                        "attached Cosign verification artifacts for {attached} trust manifest(s)"
+                    )?;
                 }
             }
             Err(error) => {
-                writeln!(stderr, "failed to attach Cosign verification artifacts: {error}")?;
+                writeln!(
+                    stderr,
+                    "failed to attach Cosign verification artifacts: {error}"
+                )?;
                 return Ok(1);
             }
         }
@@ -532,11 +538,17 @@ fn oci_push_command<R: Read, W: Write, E: Write>(
         ) {
             Ok(attached) => {
                 if attached > 0 {
-                    writeln!(stdout, "attached Cosign verification artifacts for {attached} trust manifest(s)")?;
+                    writeln!(
+                        stdout,
+                        "attached Cosign verification artifacts for {attached} trust manifest(s)"
+                    )?;
                 }
             }
             Err(error) => {
-                writeln!(stderr, "failed to attach Cosign verification artifacts: {error}")?;
+                writeln!(
+                    stderr,
+                    "failed to attach Cosign verification artifacts: {error}"
+                )?;
                 return Ok(1);
             }
         }
@@ -759,7 +771,10 @@ fn parse_oci_export_layout_options<'a>(
                 index += 1;
 
                 let Some(value) = args.get(index) else {
-                    writeln!(stderr, "oci export-layout requires a value for --cosign-key")?;
+                    writeln!(
+                        stderr,
+                        "oci export-layout requires a value for --cosign-key"
+                    )?;
                     write_usage(stderr)?;
                     return Ok(None);
                 };
@@ -770,7 +785,10 @@ fn parse_oci_export_layout_options<'a>(
                 index += 1;
 
                 let Some(value) = args.get(index) else {
-                    writeln!(stderr, "oci export-layout requires a value for --cosign-public-key")?;
+                    writeln!(
+                        stderr,
+                        "oci export-layout requires a value for --cosign-public-key"
+                    )?;
                     write_usage(stderr)?;
                     return Ok(None);
                 };
@@ -1187,7 +1205,8 @@ fn sign_blob_with_cosign(payload: &[u8], cosign_key: &str) -> io::Result<Vec<u8>
     let output = execute_cosign(&args)?;
     let result = if output.status.success() {
         let bundle_bytes = fs::read(&bundle_path)?;
-        let bundle: CosignBlobBundle = serde_json::from_slice(&bundle_bytes).map_err(io::Error::other)?;
+        let bundle: CosignBlobBundle =
+            serde_json::from_slice(&bundle_bytes).map_err(io::Error::other)?;
 
         Ok(bundle.message_signature.signature.into_bytes())
     } else {
@@ -1215,7 +1234,11 @@ fn build_cosign_sign_blob_args(
 }
 
 fn build_cosign_public_key_args(cosign_key: &str) -> Vec<String> {
-    vec!["public-key".to_owned(), "--key".to_owned(), cosign_key.to_owned()]
+    vec![
+        "public-key".to_owned(),
+        "--key".to_owned(),
+        cosign_key.to_owned(),
+    ]
 }
 
 fn execute_cosign(args: &[String]) -> io::Result<std::process::Output> {
@@ -1469,11 +1492,11 @@ fn conformance_level_name(level: ConformanceLevel) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use super::run;
     use ai_catalog_oci::{
         COSIGN_PUBLIC_KEY_ARTIFACT_TYPE, COSIGN_SIGNATURE_ARTIFACT_TYPE,
         TRUST_MANIFEST_ARTIFACT_TYPE, import_layout,
     };
-    use super::run;
 
     use serde_json::Value;
     use std::env;
@@ -1856,22 +1879,23 @@ mod tests {
         fs::create_dir_all(&tool_dir).expect("tool dir should exist");
         let script_path = write_fake_cosign_script(&tool_dir);
 
-        let (exit_code, stdout, stderr) = with_env_var(super::COSIGN_BIN_ENV, script_path.as_os_str(), || {
-            run_command(
-                [
-                    "ai-catalog-cli",
-                    "oci",
-                    "export-layout",
-                    "--cosign-key",
-                    "fake.key",
-                    "--tag",
-                    "demo",
-                    "-",
-                    layout_dir.to_str().expect("path should be utf-8"),
-                ],
-                fixture,
-            )
-        });
+        let (exit_code, stdout, stderr) =
+            with_env_var(super::COSIGN_BIN_ENV, script_path.as_os_str(), || {
+                run_command(
+                    [
+                        "ai-catalog-cli",
+                        "oci",
+                        "export-layout",
+                        "--cosign-key",
+                        "fake.key",
+                        "--tag",
+                        "demo",
+                        "-",
+                        layout_dir.to_str().expect("path should be utf-8"),
+                    ],
+                    fixture,
+                )
+            });
 
         assert_eq!(exit_code, 0);
         assert!(stdout.contains("attached Cosign verification artifacts for 1 trust manifest(s)"));
@@ -2097,12 +2121,45 @@ mod tests {
         let script_path = dir.join("fake-cosign.sh");
         let mut file = fs::File::create(&script_path).expect("script should be creatable");
 
-        write!(
-            file,
-            "{}",
-            "#!/bin/sh\nset -eu\ncmd=\"$1\"\nshift\ncase \"$cmd\" in\n  public-key)\n    echo '-----BEGIN PUBLIC KEY-----'\n    echo 'RkFLRUNPU0lHTlBVQkxJQ0tFWQ=='\n    echo '-----END PUBLIC KEY-----'\n    ;;\n  sign-blob)\n    bundle=''\n    while [ $# -gt 0 ]; do\n      case \"$1\" in\n        --bundle)\n          bundle=\"$2\"\n          shift 2\n          ;;\n        --key)\n          shift 2\n          ;;\n        --yes)\n          shift 1\n          ;;\n        *)\n          shift 1\n          ;;\n      esac\n    done\n    printf '{\"mediaType\":\"application/vnd.dev.sigstore.bundle.v0.3+json\",\"messageSignature\":{\"signature\":\"fake-cosign-signature\"}}' > \"$bundle\"\n    ;;\n  *)\n    echo \"unexpected cosign command: $cmd\" >&2\n    exit 1\n    ;;\nesac"
-        )
-        .expect("script should be writable");
+        file.write_all(
+                        br#"#!/bin/sh
+set -eu
+cmd="$1"
+shift
+case "$cmd" in
+    public-key)
+        echo '-----BEGIN PUBLIC KEY-----'
+        echo 'RkFLRUNPU0lHTlBVQkxJQ0tFWQ=='
+        echo '-----END PUBLIC KEY-----'
+        ;;
+    sign-blob)
+        bundle=''
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --bundle)
+                    bundle="$2"
+                    shift 2
+                    ;;
+                --key)
+                    shift 2
+                    ;;
+                --yes)
+                    shift 1
+                    ;;
+                *)
+                    shift 1
+                    ;;
+            esac
+        done
+        printf '{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","messageSignature":{"signature":"fake-cosign-signature"}}' > "$bundle"
+        ;;
+    *)
+        echo "unexpected cosign command: $cmd" >&2
+        exit 1
+        ;;
+esac"#,
+                )
+                .expect("script should be writable");
 
         let mut permissions = fs::metadata(&script_path)
             .expect("script metadata should exist")

--- a/crates/ai-catalog-oci/src/lib.rs
+++ b/crates/ai-catalog-oci/src/lib.rs
@@ -20,14 +20,11 @@ pub const OCI_REF_NAME_ANNOTATION: &str = "org.opencontainers.image.ref.name";
 pub const TRUST_MANIFEST_ARTIFACT_TYPE: &str = "application/vnd.ai-catalog.trust-manifest.v1+json";
 pub const TRUST_MANIFEST_CONFIG_MEDIA_TYPE: &str =
     "application/vnd.ai-catalog.trust-manifest.config.v1+json";
-pub const COSIGN_SIGNATURE_ARTIFACT_TYPE: &str =
-    "application/vnd.ai-catalog.cosign.signature.v1";
+pub const COSIGN_SIGNATURE_ARTIFACT_TYPE: &str = "application/vnd.ai-catalog.cosign.signature.v1";
 pub const COSIGN_SIGNATURE_CONFIG_MEDIA_TYPE: &str =
     "application/vnd.ai-catalog.cosign.signature.config.v1+json";
-pub const COSIGN_SIGNATURE_LAYER_MEDIA_TYPE: &str =
-    "application/vnd.dev.sigstore.cosign.signature";
-pub const COSIGN_PUBLIC_KEY_ARTIFACT_TYPE: &str =
-    "application/vnd.ai-catalog.cosign.public-key.v1";
+pub const COSIGN_SIGNATURE_LAYER_MEDIA_TYPE: &str = "application/vnd.dev.sigstore.cosign.signature";
+pub const COSIGN_PUBLIC_KEY_ARTIFACT_TYPE: &str = "application/vnd.ai-catalog.cosign.public-key.v1";
 pub const COSIGN_PUBLIC_KEY_CONFIG_MEDIA_TYPE: &str =
     "application/vnd.ai-catalog.cosign.public-key.config.v1+json";
 pub const COSIGN_PUBLIC_KEY_LAYER_MEDIA_TYPE: &str =
@@ -744,19 +741,28 @@ fn trust_manifest_annotations(manifest: &TrustManifest) -> BTreeMap<String, Stri
 fn cosign_signature_annotations(identity: &str, payload_digest: &str) -> BTreeMap<String, String> {
     BTreeMap::from([
         ("ai-catalog.identity".to_owned(), identity.to_owned()),
-        ("ai-catalog.payloadDigest".to_owned(), payload_digest.to_owned()),
+        (
+            "ai-catalog.payloadDigest".to_owned(),
+            payload_digest.to_owned(),
+        ),
         (
             "ai-catalog.payloadMediaType".to_owned(),
             TRUST_MANIFEST_ARTIFACT_TYPE.to_owned(),
         ),
-        ("ai-catalog.verificationMaterial".to_owned(), "cosign-signature".to_owned()),
+        (
+            "ai-catalog.verificationMaterial".to_owned(),
+            "cosign-signature".to_owned(),
+        ),
     ])
 }
 
 fn cosign_public_key_annotations(identity: &str, payload_digest: &str) -> BTreeMap<String, String> {
     BTreeMap::from([
         ("ai-catalog.identity".to_owned(), identity.to_owned()),
-        ("ai-catalog.payloadDigest".to_owned(), payload_digest.to_owned()),
+        (
+            "ai-catalog.payloadDigest".to_owned(),
+            payload_digest.to_owned(),
+        ),
         (
             "ai-catalog.payloadMediaType".to_owned(),
             TRUST_MANIFEST_ARTIFACT_TYPE.to_owned(),
@@ -846,10 +852,10 @@ mod tests {
 
     use super::{
         AI_CATALOG_MEDIA_TYPE, COSIGN_PUBLIC_KEY_ARTIFACT_TYPE, COSIGN_SIGNATURE_ARTIFACT_TYPE,
-        ENTRY_CONFIG_MEDIA_TYPE, Error, OCI_IMAGE_INDEX_MEDIA_TYPE,
-        OCI_IMAGE_MANIFEST_MEDIA_TYPE, OCI_LAYOUT_VERSION, OCI_REF_NAME_ANNOTATION,
-        TRUST_MANIFEST_ARTIFACT_TYPE, attach_cosign_verification_artifacts,
-        descriptor_for_bytes, export_layout, import_layout, pack_catalog, unpack_catalog,
+        ENTRY_CONFIG_MEDIA_TYPE, Error, OCI_IMAGE_INDEX_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+        OCI_LAYOUT_VERSION, OCI_REF_NAME_ANNOTATION, TRUST_MANIFEST_ARTIFACT_TYPE,
+        attach_cosign_verification_artifacts, descriptor_for_bytes, export_layout, import_layout,
+        pack_catalog, unpack_catalog,
     };
 
     #[test]
@@ -1181,10 +1187,10 @@ mod tests {
         fs::remove_dir_all(&layout_dir).expect("temp layout should be removed");
     }
 
-        #[test]
-        fn unpacks_catalog_with_additional_cosign_referrers() {
-                let catalog = parse_str(
-                        r#"{
+    #[test]
+    fn unpacks_catalog_with_additional_cosign_referrers() {
+        let catalog = parse_str(
+            r#"{
 			  "specVersion": "1.0",
 			  "entries": [
 				{
@@ -1200,31 +1206,31 @@ mod tests {
 				}
 			  ]
 			}"#,
-                )
-                .expect("catalog should parse");
-                let mut artifacts = pack_catalog(&catalog).expect("catalog should pack");
-                let entry_digest = artifacts.index.manifests[0].digest.clone();
+        )
+        .expect("catalog should parse");
+        let mut artifacts = pack_catalog(&catalog).expect("catalog should pack");
+        let entry_digest = artifacts.index.manifests[0].digest.clone();
 
-                attach_cosign_verification_artifacts(
-                        &mut artifacts,
-                        &entry_digest,
-                        "urn:example:inline",
-                        "sha256:1234abcd",
-                        b"cosign-signature",
-                        b"-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----\n",
-                )
-                .expect("cosign artifacts should attach");
+        attach_cosign_verification_artifacts(
+            &mut artifacts,
+            &entry_digest,
+            "urn:example:inline",
+            "sha256:1234abcd",
+            b"cosign-signature",
+            b"-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----\n",
+        )
+        .expect("cosign artifacts should attach");
 
-                let unpacked = unpack_catalog(&artifacts).expect("artifacts should still unpack");
+        let unpacked = unpack_catalog(&artifacts).expect("artifacts should still unpack");
 
-                assert_eq!(unpacked, catalog);
-                assert_eq!(artifacts.referrers[&entry_digest].len(), 3);
-        }
+        assert_eq!(unpacked, catalog);
+        assert_eq!(artifacts.referrers[&entry_digest].len(), 3);
+    }
 
-        #[test]
-        fn exports_and_imports_cosign_referrers() {
-                let catalog = parse_str(
-                        r#"{
+    #[test]
+    fn exports_and_imports_cosign_referrers() {
+        let catalog = parse_str(
+            r#"{
 			  "specVersion": "1.0",
 			  "entries": [
 				{
@@ -1240,37 +1246,37 @@ mod tests {
 				}
 			  ]
 			}"#,
-                )
-                .expect("catalog should parse");
-                let mut artifacts = pack_catalog(&catalog).expect("catalog should pack");
-                let entry_digest = artifacts.index.manifests[0].digest.clone();
-                let layout_dir = unique_temp_dir("ai-catalog-layout-cosign-referrers");
+        )
+        .expect("catalog should parse");
+        let mut artifacts = pack_catalog(&catalog).expect("catalog should pack");
+        let entry_digest = artifacts.index.manifests[0].digest.clone();
+        let layout_dir = unique_temp_dir("ai-catalog-layout-cosign-referrers");
 
-                attach_cosign_verification_artifacts(
-                        &mut artifacts,
-                        &entry_digest,
-                        "urn:example:inline",
-                        "sha256:1234abcd",
-                        b"cosign-signature",
-                        b"-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----\n",
-                )
-                .expect("cosign artifacts should attach");
+        attach_cosign_verification_artifacts(
+            &mut artifacts,
+            &entry_digest,
+            "urn:example:inline",
+            "sha256:1234abcd",
+            b"cosign-signature",
+            b"-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----\n",
+        )
+        .expect("cosign artifacts should attach");
 
-                export_layout(&artifacts, &layout_dir, "inline").expect("layout export should succeed");
+        export_layout(&artifacts, &layout_dir, "inline").expect("layout export should succeed");
 
-                let imported =
-                        import_layout(&layout_dir, Some("inline")).expect("layout import should succeed");
-                let imported_types = imported.referrers[&entry_digest]
-                        .iter()
-                        .filter_map(|manifest| manifest.artifact_type.as_deref())
-                        .collect::<Vec<_>>();
+        let imported =
+            import_layout(&layout_dir, Some("inline")).expect("layout import should succeed");
+        let imported_types = imported.referrers[&entry_digest]
+            .iter()
+            .filter_map(|manifest| manifest.artifact_type.as_deref())
+            .collect::<Vec<_>>();
 
-                assert!(imported_types.contains(&TRUST_MANIFEST_ARTIFACT_TYPE));
-                assert!(imported_types.contains(&COSIGN_SIGNATURE_ARTIFACT_TYPE));
-                assert!(imported_types.contains(&COSIGN_PUBLIC_KEY_ARTIFACT_TYPE));
+        assert!(imported_types.contains(&TRUST_MANIFEST_ARTIFACT_TYPE));
+        assert!(imported_types.contains(&COSIGN_SIGNATURE_ARTIFACT_TYPE));
+        assert!(imported_types.contains(&COSIGN_PUBLIC_KEY_ARTIFACT_TYPE));
 
-                fs::remove_dir_all(&layout_dir).expect("temp layout should be removed");
-        }
+        fs::remove_dir_all(&layout_dir).expect("temp layout should be removed");
+    }
 
     #[test]
     fn rejects_unknown_layout_reference() {

--- a/crates/ai-catalog-oci/src/lib.rs
+++ b/crates/ai-catalog-oci/src/lib.rs
@@ -20,6 +20,18 @@ pub const OCI_REF_NAME_ANNOTATION: &str = "org.opencontainers.image.ref.name";
 pub const TRUST_MANIFEST_ARTIFACT_TYPE: &str = "application/vnd.ai-catalog.trust-manifest.v1+json";
 pub const TRUST_MANIFEST_CONFIG_MEDIA_TYPE: &str =
     "application/vnd.ai-catalog.trust-manifest.config.v1+json";
+pub const COSIGN_SIGNATURE_ARTIFACT_TYPE: &str =
+    "application/vnd.ai-catalog.cosign.signature.v1";
+pub const COSIGN_SIGNATURE_CONFIG_MEDIA_TYPE: &str =
+    "application/vnd.ai-catalog.cosign.signature.config.v1+json";
+pub const COSIGN_SIGNATURE_LAYER_MEDIA_TYPE: &str =
+    "application/vnd.dev.sigstore.cosign.signature";
+pub const COSIGN_PUBLIC_KEY_ARTIFACT_TYPE: &str =
+    "application/vnd.ai-catalog.cosign.public-key.v1";
+pub const COSIGN_PUBLIC_KEY_CONFIG_MEDIA_TYPE: &str =
+    "application/vnd.ai-catalog.cosign.public-key.config.v1+json";
+pub const COSIGN_PUBLIC_KEY_LAYER_MEDIA_TYPE: &str =
+    "application/vnd.dev.sigstore.cosign.public-key";
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -51,6 +63,8 @@ pub enum Error {
     MissingLayoutReference(String),
     #[error("OCI layout contains multiple ai-catalog root references; pass an explicit ref name")]
     AmbiguousLayoutReference,
+    #[error("missing OCI subject descriptor for digest '{0}'")]
+    MissingSubjectDescriptor(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -134,6 +148,22 @@ struct EntryConfig {
     url: Option<String>,
     #[serde(flatten, default)]
     extra_fields: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CosignSignatureConfig {
+    identity: String,
+    payload_digest: String,
+    payload_media_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CosignPublicKeyConfig {
+    identity: String,
+    payload_digest: String,
+    format: String,
 }
 
 pub fn pack_catalog(catalog: &AiCatalog) -> Result<OciArtifactSet> {
@@ -277,7 +307,11 @@ pub fn unpack_catalog(artifacts: &OciArtifactSet) -> Result<AiCatalog> {
         let trust_manifest = artifacts
             .referrers
             .get(&descriptor.digest)
-            .and_then(|items| items.first())
+            .and_then(|items| {
+                items.iter().find(|item| {
+                    item.artifact_type.as_deref() == Some(TRUST_MANIFEST_ARTIFACT_TYPE)
+                })
+            })
             .map(|referrer| {
                 let bytes = artifacts
                     .blobs
@@ -316,6 +350,96 @@ pub fn unpack_catalog(artifacts: &OciArtifactSet) -> Result<AiCatalog> {
         metadata,
         extra_fields,
     })
+}
+
+pub fn attach_cosign_verification_artifacts(
+    artifacts: &mut OciArtifactSet,
+    subject_digest: &str,
+    identity: &str,
+    payload_digest: &str,
+    signature: &[u8],
+    public_key: &[u8],
+) -> Result<()> {
+    let subject = artifacts
+        .index
+        .manifests
+        .iter()
+        .find(|descriptor| descriptor.digest == subject_digest)
+        .cloned()
+        .ok_or_else(|| Error::MissingSubjectDescriptor(subject_digest.to_owned()))?;
+
+    let signature_config = CosignSignatureConfig {
+        identity: identity.to_owned(),
+        payload_digest: payload_digest.to_owned(),
+        payload_media_type: TRUST_MANIFEST_ARTIFACT_TYPE.to_owned(),
+    };
+    let signature_config_bytes = serde_json::to_vec(&signature_config)?;
+    let signature_config_descriptor = store_blob(
+        &mut artifacts.blobs,
+        &signature_config_bytes,
+        COSIGN_SIGNATURE_CONFIG_MEDIA_TYPE,
+        None,
+        BTreeMap::new(),
+    );
+    let signature_layer_descriptor = store_blob(
+        &mut artifacts.blobs,
+        signature,
+        COSIGN_SIGNATURE_LAYER_MEDIA_TYPE,
+        None,
+        BTreeMap::new(),
+    );
+    let signature_manifest = OciImageManifest {
+        schema_version: 2,
+        media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_owned(),
+        artifact_type: Some(COSIGN_SIGNATURE_ARTIFACT_TYPE.to_owned()),
+        config: signature_config_descriptor,
+        layers: vec![signature_layer_descriptor],
+        subject: Some(subject.clone()),
+        annotations: cosign_signature_annotations(identity, payload_digest),
+    };
+
+    let public_key_config = CosignPublicKeyConfig {
+        identity: identity.to_owned(),
+        payload_digest: payload_digest.to_owned(),
+        format: "pem".to_owned(),
+    };
+    let public_key_config_bytes = serde_json::to_vec(&public_key_config)?;
+    let public_key_config_descriptor = store_blob(
+        &mut artifacts.blobs,
+        &public_key_config_bytes,
+        COSIGN_PUBLIC_KEY_CONFIG_MEDIA_TYPE,
+        None,
+        BTreeMap::new(),
+    );
+    let public_key_layer_descriptor = store_blob(
+        &mut artifacts.blobs,
+        public_key,
+        COSIGN_PUBLIC_KEY_LAYER_MEDIA_TYPE,
+        None,
+        BTreeMap::new(),
+    );
+    let public_key_manifest = OciImageManifest {
+        schema_version: 2,
+        media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_owned(),
+        artifact_type: Some(COSIGN_PUBLIC_KEY_ARTIFACT_TYPE.to_owned()),
+        config: public_key_config_descriptor,
+        layers: vec![public_key_layer_descriptor],
+        subject: Some(subject),
+        annotations: cosign_public_key_annotations(identity, payload_digest),
+    };
+
+    artifacts
+        .referrers
+        .entry(subject_digest.to_owned())
+        .or_default()
+        .push(signature_manifest);
+    artifacts
+        .referrers
+        .entry(subject_digest.to_owned())
+        .or_default()
+        .push(public_key_manifest);
+
+    Ok(())
 }
 
 pub fn export_layout(
@@ -617,6 +741,33 @@ fn trust_manifest_annotations(manifest: &TrustManifest) -> BTreeMap<String, Stri
     BTreeMap::from([("ai-catalog.identity".to_owned(), manifest.identity.clone())])
 }
 
+fn cosign_signature_annotations(identity: &str, payload_digest: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("ai-catalog.identity".to_owned(), identity.to_owned()),
+        ("ai-catalog.payloadDigest".to_owned(), payload_digest.to_owned()),
+        (
+            "ai-catalog.payloadMediaType".to_owned(),
+            TRUST_MANIFEST_ARTIFACT_TYPE.to_owned(),
+        ),
+        ("ai-catalog.verificationMaterial".to_owned(), "cosign-signature".to_owned()),
+    ])
+}
+
+fn cosign_public_key_annotations(identity: &str, payload_digest: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("ai-catalog.identity".to_owned(), identity.to_owned()),
+        ("ai-catalog.payloadDigest".to_owned(), payload_digest.to_owned()),
+        (
+            "ai-catalog.payloadMediaType".to_owned(),
+            TRUST_MANIFEST_ARTIFACT_TYPE.to_owned(),
+        ),
+        (
+            "ai-catalog.verificationMaterial".to_owned(),
+            "cosign-public-key".to_owned(),
+        ),
+    ])
+}
+
 fn store_blob(
     blobs: &mut BTreeMap<String, Vec<u8>>,
     bytes: &[u8],
@@ -694,10 +845,11 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        AI_CATALOG_MEDIA_TYPE, ENTRY_CONFIG_MEDIA_TYPE, Error, OCI_IMAGE_INDEX_MEDIA_TYPE,
+        AI_CATALOG_MEDIA_TYPE, COSIGN_PUBLIC_KEY_ARTIFACT_TYPE, COSIGN_SIGNATURE_ARTIFACT_TYPE,
+        ENTRY_CONFIG_MEDIA_TYPE, Error, OCI_IMAGE_INDEX_MEDIA_TYPE,
         OCI_IMAGE_MANIFEST_MEDIA_TYPE, OCI_LAYOUT_VERSION, OCI_REF_NAME_ANNOTATION,
-        TRUST_MANIFEST_ARTIFACT_TYPE, descriptor_for_bytes, export_layout, import_layout,
-        pack_catalog, unpack_catalog,
+        TRUST_MANIFEST_ARTIFACT_TYPE, attach_cosign_verification_artifacts,
+        descriptor_for_bytes, export_layout, import_layout, pack_catalog, unpack_catalog,
     };
 
     #[test]
@@ -1028,6 +1180,97 @@ mod tests {
 
         fs::remove_dir_all(&layout_dir).expect("temp layout should be removed");
     }
+
+        #[test]
+        fn unpacks_catalog_with_additional_cosign_referrers() {
+                let catalog = parse_str(
+                        r#"{
+			  "specVersion": "1.0",
+			  "entries": [
+				{
+				  "identifier": "urn:example:inline",
+				  "displayName": "Inline Entry",
+				  "mediaType": "application/json",
+				  "data": {
+					"name": "inline"
+				  },
+				  "trustManifest": {
+					"identity": "urn:example:inline"
+				  }
+				}
+			  ]
+			}"#,
+                )
+                .expect("catalog should parse");
+                let mut artifacts = pack_catalog(&catalog).expect("catalog should pack");
+                let entry_digest = artifacts.index.manifests[0].digest.clone();
+
+                attach_cosign_verification_artifacts(
+                        &mut artifacts,
+                        &entry_digest,
+                        "urn:example:inline",
+                        "sha256:1234abcd",
+                        b"cosign-signature",
+                        b"-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----\n",
+                )
+                .expect("cosign artifacts should attach");
+
+                let unpacked = unpack_catalog(&artifacts).expect("artifacts should still unpack");
+
+                assert_eq!(unpacked, catalog);
+                assert_eq!(artifacts.referrers[&entry_digest].len(), 3);
+        }
+
+        #[test]
+        fn exports_and_imports_cosign_referrers() {
+                let catalog = parse_str(
+                        r#"{
+			  "specVersion": "1.0",
+			  "entries": [
+				{
+				  "identifier": "urn:example:inline",
+				  "displayName": "Inline Entry",
+				  "mediaType": "application/json",
+				  "data": {
+					"name": "inline"
+				  },
+				  "trustManifest": {
+					"identity": "urn:example:inline"
+				  }
+				}
+			  ]
+			}"#,
+                )
+                .expect("catalog should parse");
+                let mut artifacts = pack_catalog(&catalog).expect("catalog should pack");
+                let entry_digest = artifacts.index.manifests[0].digest.clone();
+                let layout_dir = unique_temp_dir("ai-catalog-layout-cosign-referrers");
+
+                attach_cosign_verification_artifacts(
+                        &mut artifacts,
+                        &entry_digest,
+                        "urn:example:inline",
+                        "sha256:1234abcd",
+                        b"cosign-signature",
+                        b"-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----\n",
+                )
+                .expect("cosign artifacts should attach");
+
+                export_layout(&artifacts, &layout_dir, "inline").expect("layout export should succeed");
+
+                let imported =
+                        import_layout(&layout_dir, Some("inline")).expect("layout import should succeed");
+                let imported_types = imported.referrers[&entry_digest]
+                        .iter()
+                        .filter_map(|manifest| manifest.artifact_type.as_deref())
+                        .collect::<Vec<_>>();
+
+                assert!(imported_types.contains(&TRUST_MANIFEST_ARTIFACT_TYPE));
+                assert!(imported_types.contains(&COSIGN_SIGNATURE_ARTIFACT_TYPE));
+                assert!(imported_types.contains(&COSIGN_PUBLIC_KEY_ARTIFACT_TYPE));
+
+                fs::remove_dir_all(&layout_dir).expect("temp layout should be removed");
+        }
 
     #[test]
     fn rejects_unknown_layout_reference() {

--- a/demo/oci-layout-walkthrough.md
+++ b/demo/oci-layout-walkthrough.md
@@ -29,5 +29,5 @@ The demo intentionally uses temporary files and directories so it can be rerun
 without cleaning up repository state. The AI Catalog JSON round-trip still only
 contains catalog and trust-manifest data; the detached Cosign signature and
 public key remain attached as OCI referrer artifacts in the layout. The script
-uses `python3` only to select the correct referrer and blob digests from the
-JSON returned by ORAS.
+uses ORAS go-template output and bash helpers to select the correct referrer and
+blob digests.

--- a/demo/oci-layout-walkthrough.md
+++ b/demo/oci-layout-walkthrough.md
@@ -1,7 +1,9 @@
 # OCI Layout Walkthrough
 
 This walkthrough exercises the standard OCI path end to end with a small trusted
-catalog that contains an inline entry and a trust manifest.
+catalog that contains an inline entry and a trust manifest. It now also uses
+Cosign to generate a temporary signing keypair and stores detached signature and
+public-key verification artifacts alongside the trust manifest in the OCI layout.
 
 Run it with:
 
@@ -12,13 +14,20 @@ just demo-oci-layout
 The script performs these steps:
 
 1. Validates the demo catalog with `ai-catalog-cli validate`.
-2. Exports a standard OCI image layout with `ai-catalog-cli oci export-layout`.
-3. Uses `oras manifest fetch` to prove the layout is readable by a standard OCI tool.
-4. Uses `oras discover` on the entry manifest digest to show the trust-manifest referrer.
-5. Imports the standard OCI layout back into AI Catalog JSON with `ai-catalog-cli oci unpack-layout`.
-6. Validates the imported catalog again.
-7. Uses `ai-catalog-cli oci push --to-oci-layout-path` to copy the artifact set into a second OCI layout through ORAS.
-8. Uses `oras discover` again to verify the copied layout still exposes the trust referrer.
+2. Generates an ephemeral Cosign keypair for the walkthrough.
+3. Exports a standard OCI image layout with `ai-catalog-cli oci export-layout --cosign-key --cosign-public-key`.
+4. Uses `oras manifest fetch` to prove the layout is readable by a standard OCI tool.
+5. Uses `oras discover` on the entry manifest digest to show the trust-manifest, Cosign signature, and Cosign public-key referrers.
+6. Fetches and prints the detached Cosign signature plus the public-key identity and PEM from those OCI referrers.
+7. Imports the standard OCI layout back into AI Catalog JSON with `ai-catalog-cli oci unpack-layout`.
+8. Validates the imported catalog again.
+9. Uses `ai-catalog-cli oci push --to-oci-layout-path --cosign-key --cosign-public-key` to copy the artifact set into a second OCI layout through ORAS.
+10. Uses `oras discover` again to verify the copied layout still exposes the trust and Cosign referrers.
+11. Fetches and prints the copied signature and public-key identity again to show the verification material survived the copy.
 
 The demo intentionally uses temporary files and directories so it can be rerun
-without cleaning up repository state.
+without cleaning up repository state. The AI Catalog JSON round-trip still only
+contains catalog and trust-manifest data; the detached Cosign signature and
+public key remain attached as OCI referrer artifacts in the layout. The script
+uses `python3` only to select the correct referrer and blob digests from the
+JSON returned by ORAS.

--- a/demo/oci-layout-walkthrough.sh
+++ b/demo/oci-layout-walkthrough.sh
@@ -5,15 +5,137 @@
 
 set -euo pipefail
 
+ORAS_BIN="${ORAS_BIN:-oras}"
+COSIGN_BIN="${COSIGN_BIN:-cosign}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+: "${COSIGN_PASSWORD:=}"
+export COSIGN_PASSWORD
+export AI_CATALOG_COSIGN_BIN="$COSIGN_BIN"
+
+TRUST_MANIFEST_ARTIFACT_TYPE="application/vnd.ai-catalog.trust-manifest.v1+json"
+COSIGN_SIGNATURE_ARTIFACT_TYPE="application/vnd.ai-catalog.cosign.signature.v1"
+COSIGN_PUBLIC_KEY_ARTIFACT_TYPE="application/vnd.ai-catalog.cosign.public-key.v1"
+
 step() {
 	echo
 	echo "== $1 =="
 }
 
-if ! command -v oras >/dev/null 2>&1; then
-	echo "oras is required for this walkthrough" >&2
-	exit 1
-fi
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "$1 is required for this walkthrough" >&2
+    exit 1
+  fi
+}
+
+assert_discovery_contains_verification_material() {
+  printf '%s\n' "$1" | grep -Fq "$TRUST_MANIFEST_ARTIFACT_TYPE"
+  printf '%s\n' "$1" | grep -Fq "$COSIGN_SIGNATURE_ARTIFACT_TYPE"
+  printf '%s\n' "$1" | grep -Fq "$COSIGN_PUBLIC_KEY_ARTIFACT_TYPE"
+}
+
+require_tool "$ORAS_BIN"
+require_tool "$COSIGN_BIN"
+require_tool "$PYTHON_BIN"
+
+referrer_digest_by_type() {
+  local discovery_json="$1"
+  local artifact_type="$2"
+
+  JSON_INPUT="$discovery_json" "$PYTHON_BIN" - "$artifact_type" <<'PY'
+import json
+import os
+import sys
+
+artifact_type = sys.argv[1]
+payload = json.loads(os.environ["JSON_INPUT"])
+
+for referrer in payload.get("referrers", []):
+    if referrer.get("artifactType") == artifact_type:
+        digest = referrer.get("digest")
+        if not digest:
+            raise SystemExit(f"missing digest for artifact type {artifact_type}")
+        print(digest)
+        raise SystemExit(0)
+
+raise SystemExit(f"missing referrer for artifact type {artifact_type}")
+PY
+}
+
+manifest_layer_digest() {
+  local manifest_json="$1"
+
+  JSON_INPUT="$manifest_json" "$PYTHON_BIN" - <<'PY'
+import json
+import os
+import sys
+
+payload = json.loads(os.environ["JSON_INPUT"])
+layers = payload.get("layers", [])
+
+if not layers:
+    raise SystemExit("manifest has no layers")
+
+digest = layers[0].get("digest")
+if not digest:
+    raise SystemExit("manifest layer is missing digest")
+
+print(digest)
+PY
+}
+
+manifest_annotation() {
+  local manifest_json="$1"
+  local key="$2"
+
+  JSON_INPUT="$manifest_json" "$PYTHON_BIN" - "$key" <<'PY'
+import json
+import os
+import sys
+
+key = sys.argv[1]
+payload = json.loads(os.environ["JSON_INPUT"])
+annotations = payload.get("annotations", {})
+value = annotations.get(key)
+
+if value is None:
+    raise SystemExit(f"missing annotation {key}")
+
+print(value)
+PY
+}
+
+print_cosign_verification_material() {
+  local layout_path="$1"
+  local discovery_json="$2"
+  local signature_referrer_digest
+  local public_key_referrer_digest
+  local signature_manifest_json
+  local public_key_manifest_json
+  local signature_layer_digest
+  local public_key_layer_digest
+  local signature
+  local public_key_identity
+  local public_key
+
+  signature_referrer_digest="$(referrer_digest_by_type "$discovery_json" "$COSIGN_SIGNATURE_ARTIFACT_TYPE")"
+  public_key_referrer_digest="$(referrer_digest_by_type "$discovery_json" "$COSIGN_PUBLIC_KEY_ARTIFACT_TYPE")"
+  signature_manifest_json="$($ORAS_BIN manifest fetch --oci-layout "${layout_path}@${signature_referrer_digest}")"
+  public_key_manifest_json="$($ORAS_BIN manifest fetch --oci-layout "${layout_path}@${public_key_referrer_digest}")"
+  signature_layer_digest="$(manifest_layer_digest "$signature_manifest_json")"
+  public_key_layer_digest="$(manifest_layer_digest "$public_key_manifest_json")"
+  signature="$($ORAS_BIN blob fetch --oci-layout --output - "${layout_path}@${signature_layer_digest}")"
+  public_key_identity="$(manifest_annotation "$public_key_manifest_json" "ai-catalog.identity")"
+  public_key="$($ORAS_BIN blob fetch --oci-layout --output - "${layout_path}@${public_key_layer_digest}")"
+
+  echo "signature artifact digest: $signature_referrer_digest"
+  echo "signature: $signature"
+  echo "public key artifact digest: $public_key_referrer_digest"
+  echo "public key identity: $public_key_identity"
+  echo "public key:"
+  printf '%s\n' "$public_key"
+}
 
 workspace_root="$(cd "$(dirname "$0")/.." && pwd)"
 tmp_root="$(mktemp -d -t ai-catalog-demo)"
@@ -21,6 +143,9 @@ catalog_json="$tmp_root/trusted-catalog.json"
 layout_dir="$tmp_root/layout"
 copied_layout_dir="$tmp_root/copied-layout"
 roundtrip_json="$tmp_root/roundtrip.json"
+cosign_key_prefix="$tmp_root/cosign"
+cosign_key="$cosign_key_prefix.key"
+cosign_pub="$cosign_key_prefix.pub"
 target_ref="example.com/ai-catalog-demo:walkthrough"
 
 cleanup() {
@@ -57,34 +182,49 @@ cd "$workspace_root"
 step "Validate the demo catalog"
 cargo run -q -p ai-catalog-cli -- validate "$catalog_json"
 
-step "Export a standard OCI image layout"
-cargo run -q -p ai-catalog-cli -- oci export-layout --tag walkthrough "$catalog_json" "$layout_dir"
+step "Generate a temporary Cosign key pair"
+"$COSIGN_BIN" generate-key-pair --output-key-prefix "$cosign_key_prefix"
+ls "$cosign_key" "$cosign_pub"
+
+step "Export a standard OCI image layout with Cosign verification artifacts"
+cargo run -q -p ai-catalog-cli -- oci export-layout --tag walkthrough --cosign-key "$cosign_key" --cosign-public-key "$cosign_pub" "$catalog_json" "$layout_dir"
 find "$layout_dir" -maxdepth 2 -type f | sort
 
 step "Fetch the root catalog artifact with ORAS"
-oras manifest fetch --oci-layout "${layout_dir}:walkthrough" --descriptor
+"$ORAS_BIN" manifest fetch --oci-layout "${layout_dir}:walkthrough" --descriptor
 
 entry_digest="$({
-	oras manifest fetch --oci-layout "${layout_dir}:walkthrough"
+  "$ORAS_BIN" manifest fetch --oci-layout "${layout_dir}:walkthrough"
 } | grep -Eo '"digest":"[^"]+"' | head -n 1 | cut -d '"' -f 4)"
 
-step "Discover trust-manifest referrers for the entry"
+step "Discover trust-manifest, Cosign signature, and public-key referrers for the entry"
 echo "entry digest: $entry_digest"
-oras discover --oci-layout "${layout_dir}@${entry_digest}" --format json
+discover_output="$($ORAS_BIN discover --oci-layout "${layout_dir}@${entry_digest}" --format json)"
+printf '%s\n' "$discover_output"
+assert_discovery_contains_verification_material "$discover_output"
+
+step "Print the detached Cosign signature and public key identity"
+print_cosign_verification_material "$layout_dir" "$discover_output"
 
 step "Import the OCI layout back into AI Catalog JSON"
 cargo run -q -p ai-catalog-cli -- oci unpack-layout --ref-name walkthrough "$layout_dir" > "$roundtrip_json"
 cat "$roundtrip_json"
+echo "note: Cosign verification artifacts remain in the OCI layout as referrers and are not projected into AI Catalog JSON"
 
 step "Validate the imported catalog"
 cargo run -q -p ai-catalog-cli -- validate "$roundtrip_json"
 
-step "Push the catalog into a second OCI layout with ORAS mediation"
-cargo run -q -p ai-catalog-cli -- oci push "$catalog_json" "$target_ref" --to-oci-layout-path "$copied_layout_dir"
-oras manifest fetch "$target_ref" --oci-layout-path "$copied_layout_dir" --descriptor
+step "Push the catalog into a second OCI layout with ORAS mediation and Cosign artifacts"
+cargo run -q -p ai-catalog-cli -- oci push --cosign-key "$cosign_key" --cosign-public-key "$cosign_pub" "$catalog_json" "$target_ref" --to-oci-layout-path "$copied_layout_dir"
+"$ORAS_BIN" manifest fetch "$target_ref" --oci-layout-path "$copied_layout_dir" --descriptor
 
-step "Verify the copied layout still exposes the trust referrer"
-oras discover --oci-layout "${copied_layout_dir}@${entry_digest}" --format json
+step "Verify the copied layout still exposes the trust and Cosign referrers"
+copied_discover_output="$($ORAS_BIN discover --oci-layout "${copied_layout_dir}@${entry_digest}" --format json)"
+printf '%s\n' "$copied_discover_output"
+assert_discovery_contains_verification_material "$copied_discover_output"
+
+step "Print the copied Cosign signature and public key identity"
+print_cosign_verification_material "$copied_layout_dir" "$copied_discover_output"
 
 step "Walkthrough complete"
 echo "temporary demo files were created under $tmp_root during execution"

--- a/demo/oci-layout-walkthrough.sh
+++ b/demo/oci-layout-walkthrough.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 ORAS_BIN="${ORAS_BIN:-oras}"
 COSIGN_BIN="${COSIGN_BIN:-cosign}"
-PYTHON_BIN="${PYTHON_BIN:-python3}"
 
 : "${COSIGN_PASSWORD:=}"
 export COSIGN_PASSWORD
@@ -37,80 +36,97 @@ assert_discovery_contains_verification_material() {
 
 require_tool "$ORAS_BIN"
 require_tool "$COSIGN_BIN"
-require_tool "$PYTHON_BIN"
 
-referrer_digest_by_type() {
-  local discovery_json="$1"
+compact_json() {
+  local payload="$1"
+
+  payload="${payload//$'\n'/}"
+  payload="${payload//$'\r'/}"
+  printf '%s\n' "$payload"
+}
+
+discover_referrer_digest_by_type() {
+  local subject_ref="$1"
   local artifact_type="$2"
+  local digest
 
-  JSON_INPUT="$discovery_json" "$PYTHON_BIN" - "$artifact_type" <<'PY'
-import json
-import os
-import sys
+  digest="$($ORAS_BIN discover --oci-layout "$subject_ref" --format go-template --template "{{range .referrers}}{{if eq (index . \"artifactType\") \"$artifact_type\"}}{{println (index . \"digest\")}}{{end}}{{end}}")"
+  digest="${digest%%$'\n'*}"
 
-artifact_type = sys.argv[1]
-payload = json.loads(os.environ["JSON_INPUT"])
+  if [[ -z "$digest" ]]; then
+    echo "missing referrer for artifact type $artifact_type" >&2
+    exit 1
+  fi
 
-for referrer in payload.get("referrers", []):
-    if referrer.get("artifactType") == artifact_type:
-        digest = referrer.get("digest")
-        if not digest:
-            raise SystemExit(f"missing digest for artifact type {artifact_type}")
-        print(digest)
-        raise SystemExit(0)
+  printf '%s\n' "$digest"
+}
 
-raise SystemExit(f"missing referrer for artifact type {artifact_type}")
-PY
+first_digest_in_array() {
+  local payload="$1"
+  local array_key="$2"
+  local compact_payload
+  local marker
+  local remainder
+  local digest
+  local quote='"'
+
+  compact_payload="$(compact_json "$payload")"
+  marker="\"${array_key}\":["
+
+  if [[ "$compact_payload" != *"$marker"* ]]; then
+    echo "missing array $array_key" >&2
+    exit 1
+  fi
+
+  remainder="${compact_payload#*"$marker"}"
+
+  if [[ "$remainder" != *'"digest":"'* ]]; then
+    echo "missing digest in $array_key" >&2
+    exit 1
+  fi
+
+  remainder="${remainder#*'"digest":"'}"
+  digest="${remainder%%${quote}*}"
+
+  printf '%s\n' "$digest"
 }
 
 manifest_layer_digest() {
   local manifest_json="$1"
 
-  JSON_INPUT="$manifest_json" "$PYTHON_BIN" - <<'PY'
-import json
-import os
-import sys
-
-payload = json.loads(os.environ["JSON_INPUT"])
-layers = payload.get("layers", [])
-
-if not layers:
-    raise SystemExit("manifest has no layers")
-
-digest = layers[0].get("digest")
-if not digest:
-    raise SystemExit("manifest layer is missing digest")
-
-print(digest)
-PY
+  first_digest_in_array "$manifest_json" "layers"
 }
 
 manifest_annotation() {
   local manifest_json="$1"
   local key="$2"
+  local compact_payload
+  local marker
+  local value
+  local quote='"'
 
-  JSON_INPUT="$manifest_json" "$PYTHON_BIN" - "$key" <<'PY'
-import json
-import os
-import sys
+  compact_payload="$(compact_json "$manifest_json")"
+  marker="\"${key}\":\""
 
-key = sys.argv[1]
-payload = json.loads(os.environ["JSON_INPUT"])
-annotations = payload.get("annotations", {})
-value = annotations.get(key)
+  if [[ "$compact_payload" != *"$marker"* ]]; then
+    echo "missing annotation $key" >&2
+    exit 1
+  fi
 
-if value is None:
-    raise SystemExit(f"missing annotation {key}")
+  value="${compact_payload#*"$marker"}"
+  value="${value%%${quote}*}"
 
-print(value)
-PY
+  printf '%s\n' "$value"
 }
 
 print_cosign_verification_material() {
   local layout_path="$1"
-  local discovery_json="$2"
+  local subject_digest="$2"
+  local subject_ref="${layout_path}@${subject_digest}"
   local signature_referrer_digest
   local public_key_referrer_digest
+  local signature_manifest_ref
+  local public_key_manifest_ref
   local signature_manifest_json
   local public_key_manifest_json
   local signature_layer_digest
@@ -119,10 +135,12 @@ print_cosign_verification_material() {
   local public_key_identity
   local public_key
 
-  signature_referrer_digest="$(referrer_digest_by_type "$discovery_json" "$COSIGN_SIGNATURE_ARTIFACT_TYPE")"
-  public_key_referrer_digest="$(referrer_digest_by_type "$discovery_json" "$COSIGN_PUBLIC_KEY_ARTIFACT_TYPE")"
-  signature_manifest_json="$($ORAS_BIN manifest fetch --oci-layout "${layout_path}@${signature_referrer_digest}")"
-  public_key_manifest_json="$($ORAS_BIN manifest fetch --oci-layout "${layout_path}@${public_key_referrer_digest}")"
+  signature_referrer_digest="$(discover_referrer_digest_by_type "$subject_ref" "$COSIGN_SIGNATURE_ARTIFACT_TYPE")"
+  public_key_referrer_digest="$(discover_referrer_digest_by_type "$subject_ref" "$COSIGN_PUBLIC_KEY_ARTIFACT_TYPE")"
+  signature_manifest_ref="${layout_path}@${signature_referrer_digest}"
+  public_key_manifest_ref="${layout_path}@${public_key_referrer_digest}"
+  signature_manifest_json="$($ORAS_BIN manifest fetch --oci-layout "$signature_manifest_ref")"
+  public_key_manifest_json="$($ORAS_BIN manifest fetch --oci-layout "$public_key_manifest_ref")"
   signature_layer_digest="$(manifest_layer_digest "$signature_manifest_json")"
   public_key_layer_digest="$(manifest_layer_digest "$public_key_manifest_json")"
   signature="$($ORAS_BIN blob fetch --oci-layout --output - "${layout_path}@${signature_layer_digest}")"
@@ -193,9 +211,8 @@ find "$layout_dir" -maxdepth 2 -type f | sort
 step "Fetch the root catalog artifact with ORAS"
 "$ORAS_BIN" manifest fetch --oci-layout "${layout_dir}:walkthrough" --descriptor
 
-entry_digest="$({
-  "$ORAS_BIN" manifest fetch --oci-layout "${layout_dir}:walkthrough"
-} | grep -Eo '"digest":"[^"]+"' | head -n 1 | cut -d '"' -f 4)"
+root_manifest_json="$($ORAS_BIN manifest fetch --oci-layout "${layout_dir}:walkthrough")"
+entry_digest="$(first_digest_in_array "$root_manifest_json" "manifests")"
 
 step "Discover trust-manifest, Cosign signature, and public-key referrers for the entry"
 echo "entry digest: $entry_digest"
@@ -204,7 +221,7 @@ printf '%s\n' "$discover_output"
 assert_discovery_contains_verification_material "$discover_output"
 
 step "Print the detached Cosign signature and public key identity"
-print_cosign_verification_material "$layout_dir" "$discover_output"
+print_cosign_verification_material "$layout_dir" "$entry_digest"
 
 step "Import the OCI layout back into AI Catalog JSON"
 cargo run -q -p ai-catalog-cli -- oci unpack-layout --ref-name walkthrough "$layout_dir" > "$roundtrip_json"
@@ -224,7 +241,7 @@ printf '%s\n' "$copied_discover_output"
 assert_discovery_contains_verification_material "$copied_discover_output"
 
 step "Print the copied Cosign signature and public key identity"
-print_cosign_verification_material "$copied_layout_dir" "$copied_discover_output"
+print_cosign_verification_material "$copied_layout_dir" "$entry_digest"
 
 step "Walkthrough complete"
 echo "temporary demo files were created under $tmp_root during execution"


### PR DESCRIPTION
## Summary
- attach Cosign signature and public-key verification artifacts as OCI referrers for trust manifests
- update OCI export and push flows to sign canonical trust manifests with Cosign bundle output
- extend the walkthrough demo to print the detached signature and public-key identity from the OCI layout

## Validation
- cargo test -p ai-catalog-oci
- cargo test -p ai-catalog-cli
- cargo clippy -p ai-catalog-oci -p ai-catalog-cli --all-targets --all-features -- -D warnings
- just demo-oci-layout