### PR TITLE
feat(ai-catalog): add get_by_id, search, and search_by_regex library APIs

### DIFF
--- a/crates/ai-catalog/Cargo.toml
+++ b/crates/ai-catalog/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/ai-catalog/src/error.rs
+++ b/crates/ai-catalog/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("regex error: {0}")]
+    Regex(#[from] regex::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/ai-catalog/src/lib.rs
+++ b/crates/ai-catalog/src/lib.rs
@@ -49,8 +49,8 @@ mod tests {
     use std::io::Cursor;
 
     use super::{
-        Error, parse_file, parse_reader, parse_slice, parse_str, to_string, to_string_pretty,
-        write_writer,
+        AiCatalog, Error, parse_file, parse_reader, parse_slice, parse_str, to_string,
+        to_string_pretty, write_writer,
     };
 
     fn canonical_fixture() -> String {
@@ -117,6 +117,138 @@ mod tests {
         assert!(matches!(
             parse_file("/definitely/missing/catalog.json"),
             Err(Error::Io(_))
+        ));
+    }
+
+    fn sample_catalog() -> AiCatalog {
+        parse_str(
+            r#"{
+                "specVersion": "1.0",
+                "entries": [
+                    {
+                        "identifier": "urn:example:agent:finance-v1",
+                        "displayName": "Finance Agent",
+                        "type": "application/a2a-agent-card+json",
+                        "description": "Handles financial queries",
+                        "tags": ["finance", "banking"],
+                        "url": "https://example.com/finance.json"
+                    },
+                    {
+                        "identifier": "urn:example:data:nlp-corpus",
+                        "displayName": "NLP Corpus",
+                        "type": "application/octet-stream",
+                        "description": "Large language model training data",
+                        "tags": ["nlp", "dataset"],
+                        "url": "https://example.com/nlp.bin"
+                    },
+                    {
+                        "identifier": "urn:example:model:embedding-v2",
+                        "type": "application/gguf",
+                        "url": "https://example.com/embed.gguf"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn get_by_id_returns_matching_entry() {
+        let catalog = sample_catalog();
+        let entry = catalog.get_by_id("urn:example:agent:finance-v1").unwrap();
+        assert_eq!(entry.identifier, "urn:example:agent:finance-v1");
+        assert_eq!(entry.display_name.as_deref(), Some("Finance Agent"));
+    }
+
+    #[test]
+    fn get_by_id_returns_none_for_unknown_id() {
+        let catalog = sample_catalog();
+        assert!(catalog.get_by_id("urn:does:not:exist").is_none());
+    }
+
+    #[test]
+    fn get_by_id_is_exact_match_only() {
+        let catalog = sample_catalog();
+        assert!(catalog.get_by_id("finance").is_none());
+        assert!(catalog.get_by_id("urn:example:agent:finance").is_none());
+    }
+
+    #[test]
+    fn search_matches_identifier_substring() {
+        let catalog = sample_catalog();
+        let results = catalog.search("nlp-corpus");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].identifier, "urn:example:data:nlp-corpus");
+    }
+
+    #[test]
+    fn search_is_case_insensitive() {
+        let catalog = sample_catalog();
+        let results = catalog.search("FINANCE");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].identifier, "urn:example:agent:finance-v1");
+    }
+
+    #[test]
+    fn search_matches_display_name() {
+        let catalog = sample_catalog();
+        let results = catalog.search("NLP Corpus");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].identifier, "urn:example:data:nlp-corpus");
+    }
+
+    #[test]
+    fn search_matches_description() {
+        let catalog = sample_catalog();
+        let results = catalog.search("financial queries");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].identifier, "urn:example:agent:finance-v1");
+    }
+
+    #[test]
+    fn search_matches_tags() {
+        let catalog = sample_catalog();
+        let results = catalog.search("dataset");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].identifier, "urn:example:data:nlp-corpus");
+    }
+
+    #[test]
+    fn search_returns_multiple_matches() {
+        let catalog = sample_catalog();
+        let results = catalog.search("urn:example");
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn search_returns_empty_for_no_match() {
+        let catalog = sample_catalog();
+        assert!(catalog.search("xyzzy-not-found").is_empty());
+    }
+
+    #[test]
+    fn search_by_regex_matches_pattern() {
+        let catalog = sample_catalog();
+        let results = catalog
+            .search_by_regex(r"urn:example:(agent|data):.*")
+            .unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn search_by_regex_anchored_identifier() {
+        let catalog = sample_catalog();
+        let results = catalog.search_by_regex(r"^urn:example:model:").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].identifier, "urn:example:model:embedding-v2");
+    }
+
+    #[test]
+    fn search_by_regex_returns_error_on_invalid_pattern() {
+        let catalog = sample_catalog();
+        assert!(matches!(
+            catalog.search_by_regex("[invalid("),
+            Err(Error::Regex(_))
         ));
     }
 }

--- a/crates/ai-catalog/src/model.rs
+++ b/crates/ai-catalog/src/model.rs
@@ -3,6 +3,7 @@
 
 use std::collections::BTreeMap;
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -18,6 +19,58 @@ pub struct AiCatalog {
     pub metadata: Option<BTreeMap<String, Value>>,
     #[serde(flatten, default)]
     pub extra_fields: BTreeMap<String, Value>,
+}
+
+impl AiCatalog {
+    /// Returns the first entry whose `identifier` exactly matches `id`.
+    pub fn get_by_id(&self, id: &str) -> Option<&CatalogEntry> {
+        self.entries.iter().find(|e| e.identifier == id)
+    }
+
+    /// Returns all entries where `query` appears (case-insensitively) in the
+    /// `identifier`, `displayName`, `description`, or any `tags` value.
+    pub fn search(&self, query: &str) -> Vec<&CatalogEntry> {
+        let q = query.to_lowercase();
+        self.entries
+            .iter()
+            .filter(|e| {
+                e.identifier.to_lowercase().contains(&q)
+                    || e.display_name
+                        .as_deref()
+                        .map(|s| s.to_lowercase().contains(&q))
+                        .unwrap_or(false)
+                    || e.description
+                        .as_deref()
+                        .map(|s| s.to_lowercase().contains(&q))
+                        .unwrap_or(false)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q))
+            })
+            .collect()
+    }
+
+    /// Returns all entries where `pattern` matches the `identifier`,
+    /// `displayName`, `description`, or any `tags` value.
+    /// Returns an error if `pattern` is not a valid regular expression.
+    pub fn search_by_regex(&self, pattern: &str) -> Result<Vec<&CatalogEntry>, crate::Error> {
+        let re = Regex::new(pattern)?;
+        let matches = self
+            .entries
+            .iter()
+            .filter(|e| {
+                re.is_match(&e.identifier)
+                    || e.display_name
+                        .as_deref()
+                        .map(|s| re.is_match(s))
+                        .unwrap_or(false)
+                    || e.description
+                        .as_deref()
+                        .map(|s| re.is_match(s))
+                        .unwrap_or(false)
+                    || e.tags.iter().any(|t| re.is_match(t))
+            })
+            .collect();
+        Ok(matches)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Adds three entry lookup methods to the `ai-catalog` crate that were present in the Go SDK but missing from the Rust library.

## Changes

- `AiCatalog::get_by_id(&str) -> Option<&CatalogEntry>` — exact identifier match
- `AiCatalog::search(&str) -> Vec<&CatalogEntry>` — case-insensitive substring across `identifier`, `displayName`, `description`, `tags`
- `AiCatalog::search_by_regex(&str) -> Result<Vec<&CatalogEntry>>` — compiled regex over the same fields; surfaces invalid patterns via `Error::Regex`

Adds `regex` (already a workspace dep) to `ai-catalog` and extends `Error` with a `Regex` variant. 13 new unit tests added.