### PR TITLE
feat(cli): add --media-type and URI-based --scope to pull and show

### DIFF
--- a/ai-catalog-cli-skill/SKILL.md
+++ b/ai-catalog-cli-skill/SKILL.md
@@ -49,7 +49,7 @@ Accepts HTTP/HTTPS URLs or `file://` paths. Nested catalogs are fetched and cach
 
 ```bash
 ai-catalog search <keyword>             # full-text search across all registered catalogs
-ai-catalog search <keyword> -n 50       # increase result limit (default 25)
+ai-catalog search <keyword> -n 100      # override result limit (default 50)
 ai-catalog search <pattern> --regex     # treat keyword as a regular expression
 ai-catalog search <keyword> --json      # machine-readable output
 ```
@@ -59,20 +59,36 @@ Searches `identifier`, `displayName`, `description`, and `tags`. Works fully off
 ### 3. Inspect an entry
 
 ```bash
-ai-catalog show <identifier>                     # table view
-ai-catalog show <identifier> --json              # full entry JSON
-ai-catalog show <identifier> --scope <catalog>   # scope lookup to one registered catalog
+ai-catalog show <identifier>                              # table view
+ai-catalog show <identifier> --json                       # full entry JSON
+ai-catalog show <identifier> --scope <catalog-name>       # scope to a registered catalog by name
+ai-catalog show <identifier> --scope <url>                # scope to any catalog by URI (file:// or http/https)
+ai-catalog show <identifier> --media-type <mime>          # filter/disambiguate by MIME type
 ```
+
+`--scope` accepts either a registered catalog name or a URI directly. `file://` URIs are read from disk; `http://`/`https://` URIs are fetched and cached on the fly without registering.
+
+`--media-type` on a catalog entry resolves its children and shows the single entry matching that type; `None` or `application/ai-catalog+json` shows the catalog entry itself.
 
 ### 4. Pull an artifact
 
 ```bash
-ai-catalog pull <identifier>                     # write to current directory
-ai-catalog pull <identifier> -o <dir>           # write to a specific directory
-ai-catalog pull <identifier> -o -               # stream to stdout (pipe to jq etc.)
+ai-catalog pull <identifier>                                 # write to current directory
+ai-catalog pull <identifier> -o <dir>                        # write to a specific directory
+ai-catalog pull <identifier> -o -                            # stream artifact bytes to stdout
+ai-catalog pull <identifier> --scope <catalog-name-or-url>   # narrow search to one catalog
+ai-catalog pull <identifier> --media-type <mime>             # required when <id> is a catalog entry
 ```
 
-When `-o -` is used, status messages go to stderr so the artifact bytes on stdout can be piped cleanly.
+**Important:** if `<identifier>` resolves to a catalog entry (type `application/ai-catalog+json`), `pull` **requires** `--media-type`:
+
+| `--media-type` value | Result |
+|---|---|
+| `application/ai-catalog+json` | Write the catalog JSON document itself |
+| `<other>` e.g. `application/json` | Pull the single child entry of that type (error if 0 or >1 match) |
+| *(omitted)* | Error — suggests using `--media-type` |
+
+`--scope` obeys the same URI rules as `show` (name or URI).
 
 ## Common workflows
 
@@ -168,8 +184,8 @@ ai-catalog oci add <name> <layout-dir>
 
 # Search, inspect, and pull from OCI-sourced catalogs only
 ai-catalog oci search <keyword>
-ai-catalog oci show <identifier>
-ai-catalog oci pull <identifier> -o <dir>
+ai-catalog oci show <identifier> [--media-type <mime>]
+ai-catalog oci pull <identifier> -o <dir> [--media-type <mime>]
 ```
 
 ## Trust inspection

--- a/ai-catalog-cli-skill/SKILL.md
+++ b/ai-catalog-cli-skill/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: ai-catalog-cli
+description: Use this skill whenever the user wants to discover, inspect, validate, or install AI resources — MCP servers, A2A agents, agent skills, or other AI artifacts — from an AI Catalog. Triggers include requests to find an MCP server, add an MCP server to Claude, install an agent skill, find or connect to an A2A agent, browse available AI tools, search a catalog, validate a catalog document, or work with OCI-packaged catalogs.
+license: Apache-2.0
+compatibility: Requires the `ai-catalog` binary on PATH. Install with `cargo install --git https://github.com/agntcy/ai-catalog-rust`.
+metadata:
+  author: ai-catalog-rust
+  version: "0.1"
+---
+
+# AI Catalog CLI
+
+`ai-catalog` is a command-line tool for discovering, validating, and pulling resources from AI Catalogs — typed JSON documents (`application/ai-catalog+json`) that index MCP servers, A2A agents, agent skills, and other AI artifacts.
+
+## Core concepts
+
+- **Catalog** — a remote JSON file (`application/ai-catalog+json`) that lists typed entries. Catalogs can nest other catalogs (fetched up to 4 levels deep).
+- **Entry** — a single item in a catalog with an `identifier` (URN), a `type` (MIME type), and a `url` pointing to the artifact.
+- **Registry** — the local list of catalogs registered via `catalog add` or `oci add`, stored at `~/.ai-catalog/`.
+
+Common entry types:
+
+| Type | Artifact |
+|------|----------|
+| `application/mcp-server-card+json` | MCP server card |
+| `application/a2a-agent-card+json` | A2A agent card |
+| `application/agent-skills+md` | Agent skill (markdown) |
+| `application/ai-catalog+json` | Nested catalog |
+
+## Workflow
+
+### 1. Register a catalog
+
+Before searching, register at least one catalog:
+
+```bash
+ai-catalog catalog add <name> <url>
+```
+
+Example:
+
+```bash
+ai-catalog catalog add ai-tools https://raw.githubusercontent.com/agntcy/ai-catalog-rust/main/fixtures/simple.json
+```
+
+Accepts HTTP/HTTPS URLs or `file://` paths. Nested catalogs are fetched and cached automatically.
+
+### 2. Search for entries
+
+```bash
+ai-catalog search <keyword>             # full-text search across all registered catalogs
+ai-catalog search <keyword> -n 50       # increase result limit (default 25)
+ai-catalog search <pattern> --regex     # treat keyword as a regular expression
+ai-catalog search <keyword> --json      # machine-readable output
+```
+
+Searches `identifier`, `displayName`, `description`, and `tags`. Works fully offline after the catalog is cached.
+
+### 3. Inspect an entry
+
+```bash
+ai-catalog show <identifier>                     # table view
+ai-catalog show <identifier> --json              # full entry JSON
+ai-catalog show <identifier> --scope <catalog>   # scope lookup to one registered catalog
+```
+
+### 4. Pull an artifact
+
+```bash
+ai-catalog pull <identifier>                     # write to current directory
+ai-catalog pull <identifier> -o <dir>           # write to a specific directory
+ai-catalog pull <identifier> -o -               # stream to stdout (pipe to jq etc.)
+```
+
+When `-o -` is used, status messages go to stderr so the artifact bytes on stdout can be piped cleanly.
+
+## Common workflows
+
+### Install an MCP server into Claude
+
+MCP server cards (`application/mcp-server-card+json`) contain a `remotes` array with endpoint URLs:
+
+```bash
+# Find the server
+ai-catalog search <keyword>
+
+# Stream the card through jq to get the remote URL
+MCP_URL=$(ai-catalog pull <identifier> -o - | jq -r '.remotes[0].url')
+
+# Register with Claude
+claude mcp add --transport http <name> "$MCP_URL"
+```
+
+### Install an agent skill into Claude
+
+Agent skills (`application/agent-skills+md`) are markdown files. Pull them into Claude's skills directory:
+
+```bash
+ai-catalog pull <identifier> -o ~/.claude/skills/
+```
+
+To install all skills matching a search:
+
+```bash
+ai-catalog search skill --json \
+  | jq -r '.entries[].identifier' \
+  | xargs -I{} ai-catalog pull {} -o ~/.claude/skills/
+```
+
+### Connect to an A2A agent
+
+A2A agent cards (`application/a2a-agent-card+json`) contain `supportedInterfaces` with the endpoint and protocol binding:
+
+```bash
+# Pull the agent card
+ai-catalog pull <identifier> -o ./
+
+# Extract endpoint and binding
+AGENT_URL=$(jq -r '.supportedInterfaces[0].url'             ./agent.json)
+BINDING=$(jq -r   '.supportedInterfaces[0].protocolBinding' ./agent.json)
+
+# Send a message
+a2acli --base-url "$AGENT_URL" --binding "$BINDING" send "<message>"
+
+# Retrieve the result
+a2acli --base-url "$AGENT_URL" --binding "$BINDING" get-task <task-id>
+```
+
+## Catalog management
+
+```bash
+ai-catalog catalog list                  # list registered catalogs (--json supported)
+ai-catalog catalog update <name>         # re-fetch from source, skip if unchanged
+ai-catalog catalog remove <name-or-url>  # remove and garbage-collect cached objects
+```
+
+## Validation and formatting
+
+```bash
+ai-catalog validate <path|->             # validate catalog JSON against the spec
+ai-catalog validate --json <path|->      # machine-readable validation result
+ai-catalog format <path|->               # pretty-print a catalog document
+```
+
+Validation reports conformance level (`minimal`, `discoverable`, or `trusted`) and any errors or warnings. Exit code 0 = valid, 1 = invalid.
+
+## OCI workflows
+
+Use `oci` subcommands to work with OCI-packaged catalogs (e.g. from GHCR):
+
+```bash
+# Pack a catalog JSON into an OCI artifact envelope
+ai-catalog oci pack <path|->
+
+# Push a catalog to an OCI registry (requires `oras` on PATH)
+ai-catalog oci push <path|-> <registry-target>
+  # e.g. ai-catalog oci push catalog.json ghcr.io/example/ai-catalog:latest
+  # --plain-http       use HTTP instead of HTTPS
+  # --insecure         skip TLS verification
+  # --cosign-key <key> sign trust manifests
+
+# Export a catalog to an OCI image layout directory
+ai-catalog oci export-layout <path|-> <layout-dir>
+  # --tag <tag>  (default: latest)
+
+# Import an OCI image layout into the local registry
+ai-catalog oci add <name> <layout-dir>
+
+# Search, inspect, and pull from OCI-sourced catalogs only
+ai-catalog oci search <keyword>
+ai-catalog oci show <identifier>
+ai-catalog oci pull <identifier> -o <dir>
+```
+
+## Trust inspection
+
+```bash
+ai-catalog trust inspect <path|->        # show trust report (identity, signatures, attestations)
+ai-catalog trust inspect --json <path|-> # machine-readable report
+```
+
+Exit code 0 = clean, 1 = errors found (identity mismatch, malformed signature, weak digest).
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AI_CATALOG_CACHE_DIR` | Override default cache directory | `~/.ai-catalog/` |
+| `AI_CATALOG_COSIGN_BIN` | Path to `cosign` binary | `cosign` |
+| `AI_CATALOG_ORAS_BIN` | Path to `oras` binary | `oras` |
+| `COSIGN_PASSWORD` | Password for encrypted Cosign private key | (none) |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Validation/trust errors, parse failures, runtime errors |
+| 2 | Usage errors (missing arguments, unknown options) |

--- a/crates/ai-catalog-cli/src/commands/oci_pull.rs
+++ b/crates/ai-catalog-cli/src/commands/oci_pull.rs
@@ -5,13 +5,17 @@ use crate::cache::CacheManager;
 use crate::error::{Error, Result};
 use crate::resolver::find_entry_by_id_oci;
 
-use super::pull::write_entry;
+use super::pull::dispatch_pull;
 
 /// Pull an OCI-sourced catalog entry by identifier and write its content to disk.
 ///
 /// Only searches catalogs added via `oci add`. If `output_path` is a directory
 /// (or omitted), a filename is derived from the identifier.
-pub async fn execute(identifier: &str, output_path: Option<&str>) -> Result<()> {
+pub async fn execute(
+    identifier: &str,
+    output_path: Option<&str>,
+    media_type: Option<&str>,
+) -> Result<()> {
     let cache = CacheManager::new()?;
 
     let entry = find_entry_by_id_oci(identifier, &cache)?
@@ -21,5 +25,5 @@ pub async fn execute(identifier: &str, output_path: Option<&str>) -> Result<()> 
             ))
         })?;
 
-    write_entry(&entry, output_path, &cache).await
+    dispatch_pull(&entry, output_path, media_type, &cache).await
 }

--- a/crates/ai-catalog-cli/src/commands/oci_show.rs
+++ b/crates/ai-catalog-cli/src/commands/oci_show.rs
@@ -5,12 +5,16 @@ use crate::cache::CacheManager;
 use crate::error::{Error, Result};
 use crate::resolver::find_entry_by_id_oci;
 
-use super::{OutputFormat, show::print_entry_table};
+use super::{OutputFormat, show::dispatch_show_entry};
 
 /// Show full details of an OCI-sourced catalog entry by identifier.
 ///
 /// Only searches catalogs added via `oci add`.
-pub async fn execute(identifier: &str, output: OutputFormat) -> Result<()> {
+pub async fn execute(
+    identifier: &str,
+    output: OutputFormat,
+    media_type: Option<&str>,
+) -> Result<()> {
     let cache = CacheManager::new()?;
 
     let entry = find_entry_by_id_oci(identifier, &cache)?
@@ -20,11 +24,5 @@ pub async fn execute(identifier: &str, output: OutputFormat) -> Result<()> {
             ))
         })?;
 
-    if let OutputFormat::Json = output {
-        println!("{}", serde_json::to_string_pretty(&entry)?);
-        return Ok(());
-    }
-
-    print_entry_table(&entry, &cache);
-    Ok(())
+    dispatch_show_entry(&entry, output, media_type, &cache).await
 }

--- a/crates/ai-catalog-cli/src/commands/pull.rs
+++ b/crates/ai-catalog-cli/src/commands/pull.rs
@@ -5,47 +5,186 @@ use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 
-use ai_catalog::CatalogEntry;
+use ai_catalog::{AiCatalog, CatalogEntry};
 
 use crate::cache::CacheManager;
 use crate::error::{Error, Result};
 use crate::fetch::build_client;
-use crate::resolver::{find_entry_by_id_in_registry, resolve_and_cache};
+use crate::resolver::{
+    find_entry_by_id_in_registry, find_entry_by_id_in_url, resolve_and_cache,
+    resolve_catalog_leaf_entries,
+};
+
+const CATALOG_MIME_TYPE: &str = "application/ai-catalog+json";
 
 /// Pull a catalog entry by identifier and write its content to disk.
 ///
-/// If `output_path` is a directory (or omitted), a filename is derived from
-/// the identifier. If it ends with a filename, that path is used directly.
-///
-/// For nested-catalog entries the full catalog JSON is written; for all other
-/// types the raw bytes fetched from `entry.url` are written (if present).
-pub async fn execute(identifier: &str, output_path: Option<&str>) -> Result<()> {
+/// `scope` restricts the search to a specific catalog (by registered name or URI).
+/// `media_type` disambiguates when the entry resolves to a catalog:
+///   - None → error
+///   - "application/ai-catalog+json" → write the catalog JSON itself
+///   - other → find the single child entry of that type and write it
+pub async fn execute(
+    identifier: &str,
+    output_path: Option<&str>,
+    scope: Option<&str>,
+    media_type: Option<&str>,
+) -> Result<()> {
     let cache = CacheManager::new()?;
+    let client = build_client()?;
 
-    // First search the local registry without hitting the network.
-    let entry = find_entry_by_id_in_registry(identifier, &cache)?;
-
-    if let Some(entry) = entry {
-        write_entry(&entry, output_path, &cache).await?;
+    let entry = if let Some(scope_val) = scope {
+        find_entry_in_scope(identifier, scope_val, &cache, &client).await?
     } else {
-        // The identifier might itself be a URL – try fetching it as a catalog.
-        if identifier.starts_with("http://") || identifier.starts_with("https://") {
-            pull_from_url(identifier, output_path, &cache).await?;
-        } else {
+        // First search the local registry without hitting the network.
+        let found = find_entry_by_id_in_registry(identifier, &cache)?;
+        if found.is_none() {
+            // The identifier might itself be a URL – try fetching it as a catalog.
+            if identifier.starts_with("http://") || identifier.starts_with("https://") {
+                return pull_from_url(identifier, output_path, &cache, &client).await;
+            }
             return Err(Error::EntryNotFound(format!(
                 "{identifier} — run `ai-catalog search {identifier}` or `ai-catalog catalog add <name> <url>` first"
             )));
         }
-    }
+        found
+    };
 
-    Ok(())
+    let entry = entry.ok_or_else(|| Error::EntryNotFound(identifier.to_string()))?;
+
+    dispatch_pull(&entry, output_path, media_type, &cache).await
 }
 
-async fn pull_from_url(url: &str, output_path: Option<&str>, cache: &CacheManager) -> Result<()> {
+/// Resolve an entry within a specific scope (registered name or URI).
+async fn find_entry_in_scope(
+    identifier: &str,
+    scope: &str,
+    cache: &CacheManager,
+    client: &reqwest::Client,
+) -> Result<Option<CatalogEntry>> {
+    if scope.contains("://") {
+        // Treat as a URI
+        if scope.starts_with("file://") {
+            find_entry_by_id_in_url(identifier, scope, cache)
+        } else {
+            // http/https — fetch and cache, then search
+            cache.ensure_dirs()?;
+            resolve_and_cache(scope, client, cache).await?;
+            let url_to_hash = cache.read_refs()?;
+            if let Some(hash) = url_to_hash.get(scope) {
+                find_entry_by_id_in_url(identifier, &cache.object_file_url(hash), cache)
+            } else {
+                Ok(None)
+            }
+        }
+    } else {
+        // Treat as a registered catalog name
+        let registry = cache.read_registry()?;
+        let catalog_entry = registry.entries.iter().find(|e| {
+            e.display_name
+                .as_deref()
+                .map(|n| n.eq_ignore_ascii_case(scope))
+                .unwrap_or(false)
+                || e.metadata
+                    .as_ref()
+                    .and_then(|m| m.get("sourceUrl"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.eq_ignore_ascii_case(scope))
+                    .unwrap_or(false)
+        });
+        let catalog_entry = catalog_entry.ok_or_else(|| {
+            Error::CatalogNotFound(format!(
+                "no catalog matching \"{scope}\" found. Use `ai-catalog catalog list` to see registered catalogs."
+            ))
+        })?;
+        let file_url = catalog_entry
+            .url
+            .as_deref()
+            .ok_or_else(|| Error::Other(format!("catalog \"{scope}\" has no local file URL")))?;
+        find_entry_by_id_in_url(identifier, file_url, cache)
+    }
+}
+
+/// Core dispatch: handle media_type gating and catalog-vs-leaf branching.
+///
+/// Also used by `oci_pull` — the client is not needed here since all data
+/// sources are either local cache or fetched inline by `write_data_entry`.
+pub(crate) async fn dispatch_pull(
+    entry: &CatalogEntry,
+    output_path: Option<&str>,
+    media_type: Option<&str>,
+    cache: &CacheManager,
+) -> Result<()> {
+    if !entry.is_nested_catalog() {
+        // Leaf entry — check media_type guard
+        if let Some(mt) = media_type
+            && entry.entry_type != mt
+        {
+            return Err(Error::Other(format!(
+                "entry \"{}\" has type \"{}\" but --media-type \"{}\" was requested",
+                entry.identifier, entry.entry_type, mt
+            )));
+        }
+        return write_entry(entry, output_path, cache).await;
+    }
+
+    // Catalog entry — branch on --media-type
+    match media_type {
+        None => Err(Error::Other(format!(
+            "\"{}\" refers to a catalog, not a pullable artifact.\n  \
+             Use --media-type {CATALOG_MIME_TYPE} to fetch the catalog JSON itself, \
+             or --media-type <type> to pull the single entry of that type within it.",
+            entry.identifier
+        ))),
+        Some(mt) if mt == CATALOG_MIME_TYPE => write_entry(entry, output_path, cache).await,
+        Some(mt) => {
+            let leaves = catalog_leaf_entries_for_entry(entry, cache)?;
+            let matches: Vec<&_> = leaves.iter().filter(|e| e.entry.entry_type == mt).collect();
+            match matches.len() {
+                0 => Err(Error::EntryNotFound(format!(
+                    "no entries of type \"{mt}\" found in catalog \"{}\"",
+                    entry.identifier
+                ))),
+                1 => write_entry(&matches[0].entry, output_path, cache).await,
+                n => Err(Error::Other(format!(
+                    "{n} entries of type \"{mt}\" found in catalog \"{}\"; \
+                     use --scope to narrow the search",
+                    entry.identifier
+                ))),
+            }
+        }
+    }
+}
+
+/// Get the leaf entries of a catalog entry using only the local cache.
+fn catalog_leaf_entries_for_entry(
+    entry: &CatalogEntry,
+    cache: &CacheManager,
+) -> Result<Vec<crate::resolver::ResolvedEntry>> {
+    let file_url = entry.url.as_deref().ok_or_else(|| {
+        Error::Other(format!("catalog entry \"{}\" has no URL", entry.identifier))
+    })?;
+
+    let path = file_url.strip_prefix("file://").unwrap_or(file_url);
+    let bytes = std::fs::read(path).map_err(|e| {
+        Error::Io(std::io::Error::new(
+            e.kind(),
+            format!("cannot read cached catalog at {file_url}: {e}"),
+        ))
+    })?;
+    let catalog: AiCatalog = serde_json::from_slice(&bytes)?;
+    resolve_catalog_leaf_entries(&catalog, file_url, cache)
+}
+
+async fn pull_from_url(
+    url: &str,
+    output_path: Option<&str>,
+    cache: &CacheManager,
+    client: &reqwest::Client,
+) -> Result<()> {
     println!("Fetching catalog from {}...", url.cyan());
-    let client = build_client()?;
     cache.ensure_dirs()?;
-    let entries = resolve_and_cache(url, &client, cache).await?;
+    let entries = resolve_and_cache(url, client, cache).await?;
     println!(
         "{} fetched {} entries from {}",
         "✓".green(),
@@ -81,7 +220,6 @@ async fn write_catalog_entry(
     output_path: Option<&str>,
     _cache: &CacheManager,
 ) -> Result<()> {
-    // For a nested catalog entry, read the locally cached file.
     let file_url = entry
         .url
         .as_deref()
@@ -107,7 +245,6 @@ async fn write_catalog_entry(
 }
 
 async fn write_data_entry(entry: &CatalogEntry, output_path: Option<&str>) -> Result<()> {
-    // Prefer inline data, fall back to fetching the URL.
     if let Some(data) = &entry.data {
         let bytes = serde_json::to_vec_pretty(data)?;
         let ext = extension_for_type(&entry.entry_type);
@@ -143,8 +280,6 @@ async fn write_data_entry(entry: &CatalogEntry, output_path: Option<&str>) -> Re
     )))
 }
 
-/// Derive a destination path from an optional user-supplied path, a stem
-/// derived from the identifier/URL, and a file extension.
 fn resolve_output_path(output_path: Option<&str>, stem: &str, ext: &str) -> PathBuf {
     let filename = safe_filename(stem, ext);
     match output_path {
@@ -160,9 +295,7 @@ fn resolve_output_path(output_path: Option<&str>, stem: &str, ext: &str) -> Path
     }
 }
 
-/// Turn an identifier or URL into a safe filename stem + the given extension.
 fn safe_filename(stem: &str, ext: &str) -> String {
-    // Use only the last component of a URN / URL path.
     let base = stem
         .rsplit(':')
         .next()
@@ -181,7 +314,6 @@ fn safe_filename(stem: &str, ext: &str) -> String {
     format!("{sanitised}.{ext}")
 }
 
-/// Pick a reasonable file extension given a MIME type string.
 fn extension_for_type(mime: &str) -> &'static str {
     match mime {
         "application/json" | "application/ai-catalog+json" => "json",

--- a/crates/ai-catalog-cli/src/commands/pull.rs
+++ b/crates/ai-catalog-cli/src/commands/pull.rs
@@ -196,9 +196,14 @@ async fn pull_from_url(
         let file_url = cache.object_file_url(hash);
         let path = file_url.strip_prefix("file://").unwrap_or(&file_url);
         let bytes = std::fs::read(path)?;
-        let dest = resolve_output_path(output_path, url, "json");
-        std::fs::write(&dest, &bytes)?;
-        println!("{} written to {}", "✓".green(), dest.display());
+        if output_path == Some("-") {
+            use std::io::Write;
+            std::io::stdout().write_all(&bytes)?;
+        } else {
+            let dest = resolve_output_path(output_path, url, "json");
+            std::fs::write(&dest, &bytes)?;
+            println!("{} written to {}", "✓".green(), dest.display());
+        }
     }
     Ok(())
 }
@@ -233,6 +238,12 @@ async fn write_catalog_entry(
         ))
     })?;
 
+    if output_path == Some("-") {
+        use std::io::Write;
+        std::io::stdout().write_all(&bytes)?;
+        return Ok(());
+    }
+
     let dest = resolve_output_path(output_path, &entry.identifier, "json");
     std::fs::write(&dest, &bytes)?;
     println!(
@@ -245,39 +256,34 @@ async fn write_catalog_entry(
 }
 
 async fn write_data_entry(entry: &CatalogEntry, output_path: Option<&str>) -> Result<()> {
-    if let Some(data) = &entry.data {
-        let bytes = serde_json::to_vec_pretty(data)?;
-        let ext = extension_for_type(&entry.entry_type);
-        let dest = resolve_output_path(output_path, &entry.identifier, ext);
-        std::fs::write(&dest, &bytes)?;
-        println!(
-            "{} \"{}\" written to {}",
-            "✓".green(),
-            entry.identifier.bold(),
-            dest.display()
-        );
-        return Ok(());
-    }
-
-    if let Some(url) = &entry.url {
+    let bytes = if let Some(data) = &entry.data {
+        serde_json::to_vec_pretty(data)?
+    } else if let Some(url) = &entry.url {
         let client = build_client()?;
-        let bytes = crate::fetch::fetch_bytes(url, &client).await?;
-        let ext = extension_for_type(&entry.entry_type);
-        let dest = resolve_output_path(output_path, &entry.identifier, ext);
-        std::fs::write(&dest, &bytes)?;
-        println!(
-            "{} \"{}\" written to {}",
-            "✓".green(),
-            entry.identifier.bold(),
-            dest.display()
-        );
+        crate::fetch::fetch_bytes(url, &client).await?
+    } else {
+        return Err(Error::Other(format!(
+            "entry \"{}\" has neither inline data nor a URL to fetch",
+            entry.identifier
+        )));
+    };
+
+    if output_path == Some("-") {
+        use std::io::Write;
+        std::io::stdout().write_all(&bytes)?;
         return Ok(());
     }
 
-    Err(Error::Other(format!(
-        "entry \"{}\" has neither inline data nor a URL to fetch",
-        entry.identifier
-    )))
+    let ext = extension_for_type(&entry.entry_type);
+    let dest = resolve_output_path(output_path, &entry.identifier, ext);
+    std::fs::write(&dest, &bytes)?;
+    println!(
+        "{} \"{}\" written to {}",
+        "✓".green(),
+        entry.identifier.bold(),
+        dest.display()
+    );
+    Ok(())
 }
 
 fn resolve_output_path(output_path: Option<&str>, stem: &str, ext: &str) -> PathBuf {

--- a/crates/ai-catalog-cli/src/commands/show.rs
+++ b/crates/ai-catalog-cli/src/commands/show.rs
@@ -7,65 +7,162 @@ use ai_catalog::{AiCatalog, CatalogEntry};
 
 use crate::cache::CacheManager;
 use crate::error::{Error, Result};
+use crate::fetch::build_client;
 use crate::resolver::{
-    find_entry_by_id_in_registry, find_entry_by_id_in_url, resolve_catalog_leaf_entries,
+    find_entry_by_id_in_registry, find_entry_by_id_in_url, resolve_and_cache,
+    resolve_catalog_leaf_entries,
 };
 
 use super::OutputFormat;
 
+const CATALOG_MIME_TYPE: &str = "application/ai-catalog+json";
+
 /// Show full details of a catalog entry by identifier.
 ///
-/// `scope` optionally restricts the search to a specific registered catalog
-/// (by name or source URL). If omitted, the entire local registry is searched.
-pub async fn execute(identifier: &str, output: OutputFormat, scope: Option<&str>) -> Result<()> {
+/// `scope` restricts the search to a specific catalog (by registered name or URI).
+/// `media_type` disambiguates when the entry resolves to a catalog:
+///   - None or "application/ai-catalog+json" → show the catalog entry itself
+///   - other → find the single child entry of that type and show it
+pub async fn execute(
+    identifier: &str,
+    output: OutputFormat,
+    scope: Option<&str>,
+    media_type: Option<&str>,
+) -> Result<()> {
     let cache = CacheManager::new()?;
+    let client = build_client()?;
 
-    let entry = if let Some(scope_name) = scope {
-        find_entry_in_scope(identifier, scope_name, &cache)?
+    let entry = if let Some(scope_val) = scope {
+        find_entry_in_scope(identifier, scope_val, &cache, &client).await?
     } else {
         find_entry_by_id_in_registry(identifier, &cache)?
     };
 
     let entry = entry.ok_or_else(|| Error::EntryNotFound(identifier.to_string()))?;
 
-    if let OutputFormat::Json = output {
-        println!("{}", serde_json::to_string_pretty(&entry)?);
-        return Ok(());
-    }
-
-    print_entry_table(&entry, &cache);
-    Ok(())
+    dispatch_show_entry(&entry, output, media_type, &cache).await
 }
 
-fn find_entry_in_scope(
-    identifier: &str,
-    scope_name: &str,
+/// Core dispatch: handle media_type gating and catalog-vs-leaf branching.
+/// Also used by `oci_show`.
+pub(crate) async fn dispatch_show_entry(
+    entry: &CatalogEntry,
+    output: OutputFormat,
+    media_type: Option<&str>,
     cache: &CacheManager,
+) -> Result<()> {
+    if !entry.is_nested_catalog() {
+        // Leaf entry — check media_type guard
+        if let Some(mt) = media_type
+            && entry.entry_type != mt
+        {
+            return Err(Error::Other(format!(
+                "entry \"{}\" has type \"{}\" but --media-type \"{}\" was requested",
+                entry.identifier, entry.entry_type, mt
+            )));
+        }
+        return print_entry(entry, &output, cache);
+    }
+
+    // Catalog entry — branch on --media-type
+    match media_type {
+        None | Some(CATALOG_MIME_TYPE) => print_entry(entry, &output, cache),
+        Some(mt) => {
+            let leaves = catalog_leaf_entries_for_entry(entry, cache)?;
+            let matches: Vec<&_> = leaves.iter().filter(|e| e.entry.entry_type == mt).collect();
+            match matches.len() {
+                0 => Err(Error::EntryNotFound(format!(
+                    "no entries of type \"{mt}\" found in catalog \"{}\"",
+                    entry.identifier
+                ))),
+                1 => print_entry(&matches[0].entry, &output, cache),
+                n => Err(Error::Other(format!(
+                    "{n} entries of type \"{mt}\" found in catalog \"{}\"; \
+                     use --scope to narrow the search",
+                    entry.identifier
+                ))),
+            }
+        }
+    }
+}
+
+/// Resolve an entry within a specific scope (registered name or URI).
+async fn find_entry_in_scope(
+    identifier: &str,
+    scope: &str,
+    cache: &CacheManager,
+    client: &reqwest::Client,
 ) -> Result<Option<CatalogEntry>> {
-    let registry = cache.read_registry()?;
-    // Find the registry entry matching the scope name or source URL
-    let catalog_entry = registry.entries.iter().find(|e| {
-        e.display_name
-            .as_deref()
-            .map(|n| n.eq_ignore_ascii_case(scope_name))
-            .unwrap_or(false)
-            || e.metadata
-                .as_ref()
-                .and_then(|m| m.get("sourceUrl"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.eq_ignore_ascii_case(scope_name))
+    if scope.contains("://") {
+        // Treat as a URI
+        if scope.starts_with("file://") {
+            find_entry_by_id_in_url(identifier, scope, cache)
+        } else {
+            // http/https — fetch and cache, then search
+            cache.ensure_dirs()?;
+            resolve_and_cache(scope, client, cache).await?;
+            let url_to_hash = cache.read_refs()?;
+            if let Some(hash) = url_to_hash.get(scope) {
+                find_entry_by_id_in_url(identifier, &cache.object_file_url(hash), cache)
+            } else {
+                Ok(None)
+            }
+        }
+    } else {
+        // Treat as a registered catalog name or sourceUrl metadata
+        let registry = cache.read_registry()?;
+        let catalog_entry = registry.entries.iter().find(|e| {
+            e.display_name
+                .as_deref()
+                .map(|n| n.eq_ignore_ascii_case(scope))
                 .unwrap_or(false)
-    });
-    let catalog_entry = catalog_entry.ok_or_else(|| {
-        Error::CatalogNotFound(format!(
-            "no catalog matching \"{scope_name}\" found. Use `ai-catalog catalog list` to see registered catalogs."
+                || e.metadata
+                    .as_ref()
+                    .and_then(|m| m.get("sourceUrl"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.eq_ignore_ascii_case(scope))
+                    .unwrap_or(false)
+        });
+        let catalog_entry = catalog_entry.ok_or_else(|| {
+            Error::CatalogNotFound(format!(
+                "no catalog matching \"{scope}\" found. Use `ai-catalog catalog list` to see registered catalogs."
+            ))
+        })?;
+        let file_url = catalog_entry
+            .url
+            .as_deref()
+            .ok_or_else(|| Error::Other(format!("catalog \"{scope}\" has no local file URL")))?;
+        find_entry_by_id_in_url(identifier, file_url, cache)
+    }
+}
+
+/// Get the leaf entries of a catalog entry using only the local cache.
+fn catalog_leaf_entries_for_entry(
+    entry: &CatalogEntry,
+    cache: &CacheManager,
+) -> Result<Vec<crate::resolver::ResolvedEntry>> {
+    let file_url = entry.url.as_deref().ok_or_else(|| {
+        Error::Other(format!("catalog entry \"{}\" has no URL", entry.identifier))
+    })?;
+
+    let path = file_url.strip_prefix("file://").unwrap_or(file_url);
+    let bytes = std::fs::read(path).map_err(|e| {
+        Error::Io(std::io::Error::new(
+            e.kind(),
+            format!("cannot read cached catalog at {file_url}: {e}"),
         ))
     })?;
-    let file_url = catalog_entry
-        .url
-        .as_deref()
-        .ok_or_else(|| Error::Other(format!("catalog \"{scope_name}\" has no local file URL")))?;
-    find_entry_by_id_in_url(identifier, file_url, cache)
+    let catalog: AiCatalog = serde_json::from_slice(&bytes)?;
+    resolve_catalog_leaf_entries(&catalog, file_url, cache)
+}
+
+fn print_entry(entry: &CatalogEntry, output: &OutputFormat, cache: &CacheManager) -> Result<()> {
+    if let OutputFormat::Json = output {
+        println!("{}", serde_json::to_string_pretty(entry)?);
+        return Ok(());
+    }
+    print_entry_table(entry, cache);
+    Ok(())
 }
 
 pub(crate) fn print_entry_table(entry: &CatalogEntry, cache: &CacheManager) {

--- a/crates/ai-catalog-cli/src/lib.rs
+++ b/crates/ai-catalog-cli/src/lib.rs
@@ -255,6 +255,7 @@ fn search_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> 
 fn show_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> {
     let mut identifier = None;
     let mut scope: Option<String> = None;
+    let mut media_type: Option<String> = None;
     let mut is_json = false;
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
@@ -263,36 +264,8 @@ fn show_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> {
             "--scope" | "-s" => {
                 scope = iter.next().map(|s| s.to_string());
             }
-            s if !s.starts_with('-') => identifier = Some(s.to_string()),
-            _ => {}
-        }
-    }
-    let Some(identifier) = identifier else {
-        writeln!(
-            stderr,
-            "usage: {BIN_NAME} show [--scope <catalog-name>] [--json] <identifier>"
-        )?;
-        return Ok(2);
-    };
-    let fmt = if is_json {
-        commands::OutputFormat::Json
-    } else {
-        commands::OutputFormat::Table
-    };
-    match run_consumer(commands::show::execute(&identifier, fmt, scope.as_deref())) {
-        Ok(()) => Ok(0),
-        Err(e) => consumer_error_to_io(e, stderr),
-    }
-}
-
-fn pull_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> {
-    let mut identifier = None;
-    let mut output_path: Option<String> = None;
-    let mut iter = args.iter();
-    while let Some(arg) = iter.next() {
-        match arg.as_str() {
-            "--output" | "-o" => {
-                output_path = iter.next().map(|s| s.to_string());
+            "--media-type" | "-m" => {
+                media_type = iter.next().map(|s| s.to_string());
             }
             s if !s.starts_with('-') => identifier = Some(s.to_string()),
             _ => {}
@@ -301,11 +274,60 @@ fn pull_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> {
     let Some(identifier) = identifier else {
         writeln!(
             stderr,
-            "usage: {BIN_NAME} pull [--output <path>] <identifier>"
+            "usage: {BIN_NAME} show [--scope <catalog-name-or-url>] [--json] [--media-type <type>] <identifier>"
         )?;
         return Ok(2);
     };
-    match run_consumer(commands::pull::execute(&identifier, output_path.as_deref())) {
+    let fmt = if is_json {
+        commands::OutputFormat::Json
+    } else {
+        commands::OutputFormat::Table
+    };
+    match run_consumer(commands::show::execute(
+        &identifier,
+        fmt,
+        scope.as_deref(),
+        media_type.as_deref(),
+    )) {
+        Ok(()) => Ok(0),
+        Err(e) => consumer_error_to_io(e, stderr),
+    }
+}
+
+fn pull_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> {
+    let mut identifier = None;
+    let mut output_path: Option<String> = None;
+    let mut scope: Option<String> = None;
+    let mut media_type: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--output" | "-o" => {
+                output_path = iter.next().map(|s| s.to_string());
+            }
+            "--scope" | "-s" => {
+                scope = iter.next().map(|s| s.to_string());
+            }
+            "--media-type" | "-m" => {
+                media_type = iter.next().map(|s| s.to_string());
+            }
+            s if !s.starts_with('-') => identifier = Some(s.to_string()),
+            _ => {}
+        }
+    }
+    let Some(identifier) = identifier else {
+        writeln!(
+            stderr,
+            "usage: {BIN_NAME} pull [--output <path>] [--scope <catalog-name-or-url>] [--media-type <type>] <identifier>"
+        )?;
+        return Ok(2);
+    };
+    match run_consumer(commands::pull::execute(
+        &identifier,
+        output_path.as_deref(),
+        scope.as_deref(),
+        media_type.as_deref(),
+    )) {
         Ok(()) => Ok(0),
         Err(e) => consumer_error_to_io(e, stderr),
     }
@@ -770,36 +792,13 @@ fn oci_search_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i
 fn oci_show_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> {
     let mut identifier = None;
     let mut is_json = false;
-    for arg in args {
-        match arg.as_str() {
-            "--json" | "-j" => is_json = true,
-            s if !s.starts_with('-') => identifier = Some(s.to_string()),
-            _ => {}
-        }
-    }
-    let Some(identifier) = identifier else {
-        writeln!(stderr, "usage: {BIN_NAME} oci show [--json] <identifier>")?;
-        return Ok(2);
-    };
-    let fmt = if is_json {
-        commands::OutputFormat::Json
-    } else {
-        commands::OutputFormat::Table
-    };
-    match run_consumer(commands::oci_show::execute(&identifier, fmt)) {
-        Ok(()) => Ok(0),
-        Err(e) => consumer_error_to_io(e, stderr),
-    }
-}
-
-fn oci_pull_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> {
-    let mut identifier = None;
-    let mut output_path: Option<String> = None;
+    let mut media_type: Option<String> = None;
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
-            "--output" | "-o" => {
-                output_path = iter.next().map(|s| s.to_string());
+            "--json" | "-j" => is_json = true,
+            "--media-type" | "-m" => {
+                media_type = iter.next().map(|s| s.to_string());
             }
             s if !s.starts_with('-') => identifier = Some(s.to_string()),
             _ => {}
@@ -808,13 +807,53 @@ fn oci_pull_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32
     let Some(identifier) = identifier else {
         writeln!(
             stderr,
-            "usage: {BIN_NAME} oci pull [--output <path>] <identifier>"
+            "usage: {BIN_NAME} oci show [--json] [--media-type <type>] <identifier>"
+        )?;
+        return Ok(2);
+    };
+    let fmt = if is_json {
+        commands::OutputFormat::Json
+    } else {
+        commands::OutputFormat::Table
+    };
+    match run_consumer(commands::oci_show::execute(
+        &identifier,
+        fmt,
+        media_type.as_deref(),
+    )) {
+        Ok(()) => Ok(0),
+        Err(e) => consumer_error_to_io(e, stderr),
+    }
+}
+
+fn oci_pull_command<E: Write>(args: &[String], stderr: &mut E) -> io::Result<i32> {
+    let mut identifier = None;
+    let mut output_path: Option<String> = None;
+    let mut media_type: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--output" | "-o" => {
+                output_path = iter.next().map(|s| s.to_string());
+            }
+            "--media-type" | "-m" => {
+                media_type = iter.next().map(|s| s.to_string());
+            }
+            s if !s.starts_with('-') => identifier = Some(s.to_string()),
+            _ => {}
+        }
+    }
+    let Some(identifier) = identifier else {
+        writeln!(
+            stderr,
+            "usage: {BIN_NAME} oci pull [--output <path>] [--media-type <type>] <identifier>"
         )?;
         return Ok(2);
     };
     match run_consumer(commands::oci_pull::execute(
         &identifier,
         output_path.as_deref(),
+        media_type.as_deref(),
     )) {
         Ok(()) => Ok(0),
         Err(e) => consumer_error_to_io(e, stderr),
@@ -1364,10 +1403,13 @@ fn write_usage(writer: &mut impl Write) -> io::Result<()> {
         writer,
         "  {BIN_NAME} oci search [--regex] [-n <limit>] [--json] <keyword>"
     )?;
-    writeln!(writer, "  {BIN_NAME} oci show [--json] <identifier>")?;
     writeln!(
         writer,
-        "  {BIN_NAME} oci pull [--output <path>] <identifier>"
+        "  {BIN_NAME} oci show [--json] [--media-type <type>] <identifier>"
+    )?;
+    writeln!(
+        writer,
+        "  {BIN_NAME} oci pull [--output <path>] [--media-type <type>] <identifier>"
     )?;
     writeln!(writer, "  {BIN_NAME} catalog add <name> <url>")?;
     writeln!(writer, "  {BIN_NAME} catalog list [--json]")?;
@@ -1379,9 +1421,12 @@ fn write_usage(writer: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         writer,
-        "  {BIN_NAME} show [--scope <catalog-name>] [--json] <identifier>"
+        "  {BIN_NAME} show [--scope <catalog-name-or-url>] [--json] [--media-type <type>] <identifier>"
     )?;
-    writeln!(writer, "  {BIN_NAME} pull [--output <path>] <identifier>")?;
+    writeln!(
+        writer,
+        "  {BIN_NAME} pull [--output <path>] [--scope <catalog-name-or-url>] [--media-type <type>] <identifier>"
+    )?;
     writeln!(writer, "  {BIN_NAME} help")?;
     writeln!(writer, "  {BIN_NAME} version")?;
     writeln!(writer)?;

--- a/crates/ai-catalog-cli/tests/cli_binary.rs
+++ b/crates/ai-catalog-cli/tests/cli_binary.rs
@@ -416,3 +416,319 @@ fn pull_missing_identifier_fails() {
         "{stderr}"
     );
 }
+
+// ── --media-type tests ────────────────────────────────────────────────────────
+
+/// Write a parent catalog whose single entry is a nested catalog pointing at `child_url`.
+/// Returns the `file://` URL of the parent.
+fn write_nested_catalog(dir: &Path, child_url: &str) -> String {
+    let parent_json = format!(
+        r#"{{
+  "specVersion": "1.0",
+  "entries": [
+    {{
+      "identifier": "urn:test:nested-catalog",
+      "displayName": "Nested Catalog",
+      "type": "application/ai-catalog+json",
+      "url": "{child_url}"
+    }}
+  ]
+}}"#
+    );
+    let path = dir.join("parent-catalog.json");
+    fs::write(&path, parent_json).expect("parent catalog should be writable");
+    format!("file://{}", path.display())
+}
+
+/// Write a child catalog with one entry of type `application/json` (inline data).
+fn write_child_catalog(dir: &Path) -> String {
+    let child_json = r#"{
+  "specVersion": "1.0",
+  "entries": [
+    {
+      "identifier": "urn:test:child-agent",
+      "displayName": "Child Agent",
+      "type": "application/json",
+      "data": {"name": "child"}
+    }
+  ]
+}"#;
+    let path = dir.join("child-catalog.json");
+    fs::write(&path, child_json).expect("child catalog should be writable");
+    format!("file://{}", path.display())
+}
+
+/// Write a child catalog with TWO entries of the same type (for ambiguity tests).
+fn write_child_catalog_two_json(dir: &Path) -> String {
+    let child_json = r#"{
+  "specVersion": "1.0",
+  "entries": [
+    {
+      "identifier": "urn:test:child-a",
+      "type": "application/json",
+      "data": {"name": "a"}
+    },
+    {
+      "identifier": "urn:test:child-b",
+      "type": "application/json",
+      "data": {"name": "b"}
+    }
+  ]
+}"#;
+    let path = dir.join("child-two.json");
+    fs::write(&path, child_json).expect("child catalog (two) should be writable");
+    format!("file://{}", path.display())
+}
+
+#[test]
+fn pull_catalog_entry_without_media_type_errors() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let child_url = write_child_catalog(catalog_dir.path());
+    let child_url = child_url.strip_prefix("file://").unwrap().to_owned();
+    let parent_url = write_nested_catalog(catalog_dir.path(), &child_url);
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "nested-test", &parent_url]));
+
+    let (ok, _, stderr) = run(cmd_with_home(home.path()).args(["pull", "urn:test:nested-catalog"]));
+    assert!(
+        !ok,
+        "pull should fail when id is a catalog without --media-type"
+    );
+    assert!(
+        stderr.contains("refers to a catalog"),
+        "error should mention catalog: {stderr}"
+    );
+    assert!(
+        stderr.contains("--media-type"),
+        "error should suggest --media-type: {stderr}"
+    );
+}
+
+#[test]
+fn pull_catalog_entry_with_catalog_media_type_writes_file() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let child_url = write_child_catalog(catalog_dir.path());
+    let child_url_path = child_url.strip_prefix("file://").unwrap().to_owned();
+    let parent_url = write_nested_catalog(catalog_dir.path(), &child_url_path);
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "nested-catalog-mt", &parent_url]));
+
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let (ok, _, stderr) = run(cmd_with_home(home.path()).args([
+        "pull",
+        "--media-type",
+        "application/ai-catalog+json",
+        "--output",
+        out_dir.path().to_str().unwrap(),
+        "urn:test:nested-catalog",
+    ]));
+    assert!(ok, "pull with catalog media-type should succeed: {stderr}");
+    // At least one file should be written
+    let files: Vec<_> = fs::read_dir(out_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(!files.is_empty(), "output directory should contain a file");
+}
+
+#[test]
+fn pull_catalog_entry_with_child_media_type_pulls_child() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let child_url = write_child_catalog(catalog_dir.path());
+    let child_url_path = child_url.strip_prefix("file://").unwrap().to_owned();
+    let parent_url = write_nested_catalog(catalog_dir.path(), &child_url_path);
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "nested-child-mt", &parent_url]));
+
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let (ok, _, stderr) = run(cmd_with_home(home.path()).args([
+        "pull",
+        "--media-type",
+        "application/json",
+        "--output",
+        out_dir.path().to_str().unwrap(),
+        "urn:test:nested-catalog",
+    ]));
+    assert!(ok, "pull with child media-type should succeed: {stderr}");
+    let files: Vec<_> = fs::read_dir(out_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(
+        !files.is_empty(),
+        "output directory should contain the child entry file"
+    );
+}
+
+#[test]
+fn pull_catalog_entry_with_ambiguous_media_type_errors() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let child_url = write_child_catalog_two_json(catalog_dir.path());
+    let child_url_path = child_url.strip_prefix("file://").unwrap().to_owned();
+    let parent_url = write_nested_catalog(catalog_dir.path(), &child_url_path);
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "ambiguous-mt", &parent_url]));
+
+    let (ok, _, stderr) = run(cmd_with_home(home.path()).args([
+        "pull",
+        "--media-type",
+        "application/json",
+        "urn:test:nested-catalog",
+    ]));
+    assert!(
+        !ok,
+        "pull should fail when multiple children match the media type"
+    );
+    assert!(
+        stderr.contains("2") || stderr.contains("entries of type"),
+        "error should mention multiple matches: {stderr}"
+    );
+}
+
+#[test]
+fn pull_leaf_entry_with_wrong_media_type_errors() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let catalog_url = write_fixture_catalog(catalog_dir.path());
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "leaf-mt-test", &catalog_url]));
+
+    let (ok, _, stderr) = run(cmd_with_home(home.path()).args([
+        "pull",
+        "--media-type",
+        "text/plain",
+        "urn:test:agent-alpha",
+    ]));
+    assert!(!ok, "pull should fail on type mismatch");
+    assert!(
+        stderr.contains("--media-type") || stderr.contains("type"),
+        "error should mention type mismatch: {stderr}"
+    );
+}
+
+#[test]
+fn show_catalog_entry_without_media_type_succeeds() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let child_url = write_child_catalog(catalog_dir.path());
+    let child_url_path = child_url.strip_prefix("file://").unwrap().to_owned();
+    let parent_url = write_nested_catalog(catalog_dir.path(), &child_url_path);
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "show-cat-no-mt", &parent_url]));
+
+    let (ok, stdout, stderr) =
+        run(cmd_with_home(home.path()).args(["show", "urn:test:nested-catalog"]));
+    assert!(
+        ok,
+        "show should succeed for a catalog entry without --media-type: {stderr}"
+    );
+    assert!(
+        stdout.contains("urn:test:nested-catalog"),
+        "show output should contain the identifier: {stdout}"
+    );
+}
+
+#[test]
+fn show_catalog_entry_with_child_media_type_shows_child() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let child_url = write_child_catalog(catalog_dir.path());
+    let child_url_path = child_url.strip_prefix("file://").unwrap().to_owned();
+    let parent_url = write_nested_catalog(catalog_dir.path(), &child_url_path);
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "show-child-mt", &parent_url]));
+
+    let (ok, stdout, stderr) = run(cmd_with_home(home.path()).args([
+        "show",
+        "--media-type",
+        "application/json",
+        "urn:test:nested-catalog",
+    ]));
+    assert!(ok, "show with child media-type should succeed: {stderr}");
+    assert!(
+        stdout.contains("urn:test:child-agent"),
+        "show output should contain the child entry: {stdout}"
+    );
+}
+
+#[test]
+fn show_leaf_entry_with_wrong_media_type_errors() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let catalog_url = write_fixture_catalog(catalog_dir.path());
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "show-leaf-mt", &catalog_url]));
+
+    let (ok, _, stderr) = run(cmd_with_home(home.path()).args([
+        "show",
+        "--media-type",
+        "text/plain",
+        "urn:test:agent-alpha",
+    ]));
+    assert!(!ok, "show should fail on type mismatch");
+    assert!(
+        stderr.contains("--media-type") || stderr.contains("type"),
+        "error should mention type mismatch: {stderr}"
+    );
+}
+
+// ── --scope URI tests ─────────────────────────────────────────────────────────
+
+#[test]
+fn show_scope_by_file_url_finds_entry() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let catalog_url = write_fixture_catalog(catalog_dir.path());
+
+    // Use --scope with the file:// URL directly, without registering the catalog
+    let (ok, stdout, stderr) = run(cmd_with_home(home.path()).args([
+        "show",
+        "--scope",
+        &catalog_url,
+        "urn:test:agent-alpha",
+    ]));
+    assert!(ok, "show --scope <file-url> should succeed: {stderr}");
+    assert!(
+        stdout.contains("urn:test:agent-alpha"),
+        "output should contain the entry: {stdout}"
+    );
+}
+
+#[test]
+fn pull_scope_by_file_url_pulls_entry() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let child_json = r#"{
+  "specVersion": "1.0",
+  "entries": [
+    {
+      "identifier": "urn:test:scoped-agent",
+      "type": "application/json",
+      "data": {"name": "scoped"}
+    }
+  ]
+}"#;
+    let catalog_path = catalog_dir.path().join("scoped-catalog.json");
+    fs::write(&catalog_path, child_json).unwrap();
+    let catalog_url = format!("file://{}", catalog_path.display());
+
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let (ok, _, stderr) = run(cmd_with_home(home.path()).args([
+        "pull",
+        "--scope",
+        &catalog_url,
+        "--output",
+        out_dir.path().to_str().unwrap(),
+        "urn:test:scoped-agent",
+    ]));
+    assert!(ok, "pull --scope <file-url> should succeed: {stderr}");
+    let files: Vec<_> = fs::read_dir(out_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(!files.is_empty(), "output should contain the pulled file");
+}

--- a/crates/ai-catalog-cli/tests/cli_binary.rs
+++ b/crates/ai-catalog-cli/tests/cli_binary.rs
@@ -732,3 +732,36 @@ fn pull_scope_by_file_url_pulls_entry() {
         .collect();
     assert!(!files.is_empty(), "output should contain the pulled file");
 }
+
+#[test]
+fn pull_output_stdout_streams_bytes() {
+    let home = tempfile::TempDir::new().unwrap();
+    let catalog_dir = tempfile::TempDir::new().unwrap();
+    let catalog_json = r#"{
+  "specVersion": "1.0",
+  "entries": [
+    {
+      "identifier": "urn:test:stdout-entry",
+      "type": "application/json",
+      "data": {"hello": "world"}
+    }
+  ]
+}"#;
+    let catalog_path = catalog_dir.path().join("stdout-catalog.json");
+    fs::write(&catalog_path, catalog_json).unwrap();
+    let catalog_url = format!("file://{}", catalog_path.display());
+
+    run(cmd_with_home(home.path()).args(["catalog", "add", "stdout-test", &catalog_url]));
+
+    let (ok, stdout, stderr) = run(cmd_with_home(home.path()).args([
+        "pull",
+        "--output",
+        "-",
+        "urn:test:stdout-entry",
+    ]));
+    assert!(ok, "pull -o - should succeed: {stderr}");
+    // stdout should contain JSON bytes, not write a file named "-"
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    assert_eq!(parsed["hello"], "world");
+}


### PR DESCRIPTION
## Summary

- `pull <id>` where `<id>` resolves to a catalog entry now **errors** unless `--media-type` is supplied, matching the `air-cli` reference behaviour. Passing `--media-type application/ai-catalog+json` fetches the catalog JSON itself; any other value pulls the single child entry of that type (errors on 0 or >1 matches).
- `show` gains the same `--media-type` dispatch (without it, a catalog entry is still displayed as before — no breaking change).
- `--scope` on both `pull` and `show` now accepts a **URI** directly (`file://` is read from disk, `http://`/`https://` is fetched and cached on the fly). Non-URI values continue to be treated as registered catalog names.
- `pull` gains a `--scope` flag (previously only `show` had it).
- `oci pull` and `oci show` both receive the same `--media-type` flag.
- 10 new integration tests cover all new behaviours; all 90 tests pass and `just lint` is clean.