### PR TITLE
fix: bugs and spec conformance

### DIFF
--- a/crates/ai-catalog-trust/src/lib.rs
+++ b/crates/ai-catalog-trust/src/lib.rs
@@ -1,7 +1,10 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-use ai_catalog::{AiCatalog, CatalogEntry, HostInfo, TrustManifest};
+use ai_catalog::{
+    AiCatalog, CatalogEntry, HostInfo, TrustManifest, identity_binds_to_entry, identity_domain,
+    publisher_domain,
+};
 use serde_json::{Map, Value};
 use sha2::{Digest as _, Sha256, Sha384, Sha512};
 use thiserror::Error;
@@ -52,6 +55,10 @@ pub struct CatalogTrustReport {
     pub entries: Vec<ManifestReport>,
 }
 
+const SHA256_HEX_LEN: usize = 64;
+const SHA384_HEX_LEN: usize = 96;
+const SHA512_HEX_LEN: usize = 128;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedDigest {
     algorithm: String,
@@ -70,15 +77,19 @@ impl ParsedDigest {
 
         let normalized_algorithm = algorithm.to_ascii_lowercase();
 
-        match normalized_algorithm.as_str() {
-            "sha256" | "sha384" | "sha512" => {}
+        let expected_len = match normalized_algorithm.as_str() {
+            "sha256" => SHA256_HEX_LEN,
+            "sha384" => SHA384_HEX_LEN,
+            "sha512" => SHA512_HEX_LEN,
             "md5" | "sha1" | "sha224" => {
                 return Err(Error::WeakDigestAlgorithm(normalized_algorithm));
             }
             _ => return Err(Error::UnsupportedDigestAlgorithm(normalized_algorithm)),
-        }
+        };
 
-        if !hex_value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        if hex_value.len() != expected_len
+            || !hex_value.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
             return Err(Error::InvalidDigestHex);
         }
 
@@ -189,13 +200,14 @@ fn analyze_entry_manifest(entry: &CatalogEntry, index: usize) -> Option<Manifest
     let path = format!("catalog.entries[{index}].trustManifest");
     let mut findings = Vec::new();
 
-    if manifest.identity != entry.identifier {
+    if identity_binds_to_entry(&entry.identifier, &manifest.identity) == Some(false) {
         findings.push(Finding {
             severity: Severity::Error,
             path: format!("{path}.identity"),
             message: format!(
-                "trustManifest.identity '{}' MUST match entry identifier '{}'",
-                manifest.identity, entry.identifier
+                "trustManifest.identity domain '{}' MUST align with entry identifier publisher domain '{}'",
+                identity_domain(&manifest.identity).unwrap_or_default(),
+                publisher_domain(&entry.identifier).unwrap_or_default()
             ),
         });
     }
@@ -397,6 +409,24 @@ mod tests {
     }
 
     #[test]
+    fn rejects_hex_values_of_the_wrong_length() {
+        assert!(matches!(
+            ParsedDigest::parse("sha256:abc"),
+            Err(Error::InvalidDigestHex)
+        ));
+        assert!(matches!(
+            ParsedDigest::parse(
+                "sha512:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+            ),
+            Err(Error::InvalidDigestHex)
+        ));
+        assert!(matches!(
+            ParsedDigest::parse(&"z".repeat(64).prepend_with_algorithm("sha256")),
+            Err(Error::InvalidDigestHex)
+        ));
+    }
+
+    #[test]
     fn canonicalizes_manifest_without_signature() {
         let catalog = parse_catalog(
             r#"{
@@ -447,12 +477,12 @@ mod tests {
 			  },
 			  "entries": [
 				{
-				  "identifier": "urn:example:artifact",
+				  "identifier": "urn:air:acme.com:agent:artifact",
 				  "displayName": "Artifact",
 				  "type": "application/json",
 				  "url": "https://example.com/artifact.json",
 				  "trustManifest": {
-					"identity": "plain-identifier",
+					"identity": "did:web:evil.example",
 					"signature": "header.payload.signature",
 					"trustSchema": {
 					  "identifier": "",
@@ -462,7 +492,6 @@ mod tests {
 					  {
 						"type": "",
 						"uri": "",
-						"mediaType": "application/jwt",
 						"digest": "md5:abcd"
 					  }
 					],
@@ -497,12 +526,7 @@ mod tests {
         assert!(contains_finding(
             &report,
             Severity::Error,
-            "trustManifest.identity 'plain-identifier' MUST match entry identifier 'urn:example:artifact'"
-        ));
-        assert!(contains_finding(
-            &report,
-            Severity::Warning,
-            "trust manifest identity SHOULD be a URI-like identifier"
+            "trustManifest.identity domain 'evil.example' MUST align with entry identifier publisher domain 'acme.com'"
         ));
         assert!(contains_finding(
             &report,
@@ -514,6 +538,59 @@ mod tests {
             Severity::Error,
             "digest hex value contains non-hex characters"
         ));
+    }
+
+    #[test]
+    fn non_uri_identity_warns_without_binding_error() {
+        let report = analyze_catalog(&parse_catalog(
+            r#"{
+			  "specVersion": "1.0",
+			  "entries": [
+				{
+				  "identifier": "urn:example:artifact",
+				  "displayName": "Artifact",
+				  "type": "application/json",
+				  "url": "https://example.com/artifact.json",
+				  "trustManifest": {
+					"identity": "plain-identifier"
+				  }
+				}
+			  ]
+			}"#,
+        ));
+
+        assert!(contains_finding(
+            &report,
+            Severity::Warning,
+            "trust manifest identity SHOULD be a URI-like identifier"
+        ));
+        assert!(!contains_finding(
+            &report,
+            Severity::Error,
+            "MUST align with entry identifier publisher domain"
+        ));
+    }
+
+    #[test]
+    fn identity_binding_accepts_aligned_domains() {
+        let report = analyze_catalog(&parse_catalog(
+            r#"{
+			  "specVersion": "1.0",
+			  "entries": [
+				{
+				  "identifier": "urn:air:acme.com:agent:artifact",
+				  "displayName": "Artifact",
+				  "type": "application/json",
+				  "url": "https://acme.com/artifact.json",
+				  "trustManifest": {
+					"identity": "did:web:acme.com"
+				  }
+				}
+			  ]
+			}"#,
+        ));
+
+        assert!(report.findings.is_empty());
     }
 
     #[test]
@@ -546,7 +623,6 @@ mod tests {
 					  {
 						"type": "publisher-identity",
 						"uri": "https://example.com/publisher.jwt",
-						"mediaType": "application/jwt",
 						"digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 					  }
 					],

--- a/crates/ai-catalog-trust/src/lib.rs
+++ b/crates/ai-catalog-trust/src/lib.rs
@@ -201,14 +201,21 @@ fn analyze_entry_manifest(entry: &CatalogEntry, index: usize) -> Option<Manifest
     let mut findings = Vec::new();
 
     if identity_binds_to_entry(&entry.identifier, &manifest.identity) == Some(false) {
+        let publisher = publisher_domain(&entry.identifier).unwrap_or_default();
+        let message = match identity_domain(&manifest.identity) {
+            Some(domain) => format!(
+                "trustManifest.identity domain '{domain}' MUST align with entry identifier publisher domain '{publisher}'"
+            ),
+            None => format!(
+                "trustManifest.identity '{}' MUST carry a trust domain aligned with entry identifier publisher domain '{publisher}'",
+                manifest.identity
+            ),
+        };
+
         findings.push(Finding {
             severity: Severity::Error,
             path: format!("{path}.identity"),
-            message: format!(
-                "trustManifest.identity domain '{}' MUST align with entry identifier publisher domain '{}'",
-                identity_domain(&manifest.identity).unwrap_or_default(),
-                publisher_domain(&entry.identifier).unwrap_or_default()
-            ),
+            message,
         });
     }
 
@@ -568,6 +575,32 @@ mod tests {
             &report,
             Severity::Error,
             "MUST align with entry identifier publisher domain"
+        ));
+    }
+
+    #[test]
+    fn identity_without_trust_domain_fails_binding() {
+        let report = analyze_catalog(&parse_catalog(
+            r#"{
+			  "specVersion": "1.0",
+			  "entries": [
+				{
+				  "identifier": "urn:air:acme.com:agent:artifact",
+				  "displayName": "Artifact",
+				  "type": "application/json",
+				  "url": "https://acme.com/artifact.json",
+				  "trustManifest": {
+					"identity": "urn:acme:agent:artifact"
+				  }
+				}
+			  ]
+			}"#,
+        ));
+
+        assert!(contains_finding(
+            &report,
+            Severity::Error,
+            "MUST carry a trust domain aligned with entry identifier publisher domain 'acme.com'"
         ));
     }
 

--- a/crates/ai-catalog-validate/src/lib.rs
+++ b/crates/ai-catalog-validate/src/lib.rs
@@ -196,15 +196,18 @@ fn validate_entry(
         );
 
         if identity_binds_to_entry(&entry.identifier, &trust_manifest.identity) == Some(false) {
-            push_error(
-                errors,
-                format!("{path}.trustManifest.identity"),
-                format!(
-                    "trustManifest.identity domain '{}' does not align with the entry identifier publisher domain '{}'",
-                    identity_domain(&trust_manifest.identity).unwrap_or_default(),
-                    publisher_domain(&entry.identifier).unwrap_or_default()
+            let publisher = publisher_domain(&entry.identifier).unwrap_or_default();
+            let message = match identity_domain(&trust_manifest.identity) {
+                Some(domain) => format!(
+                    "trustManifest.identity domain '{domain}' does not align with the entry identifier publisher domain '{publisher}'"
                 ),
-            );
+                None => format!(
+                    "trustManifest.identity '{}' has no trust domain to align with the entry identifier publisher domain '{publisher}'",
+                    trust_manifest.identity
+                ),
+            };
+
+            push_error(errors, format!("{path}.trustManifest.identity"), message);
         }
     }
 
@@ -427,6 +430,35 @@ mod tests {
             diagnostic
                 .message
                 .contains("does not align with the entry identifier publisher domain")
+        }));
+    }
+
+    #[test]
+    fn rejects_trust_identity_without_a_trust_domain() {
+        let catalog = parse_str(
+            r#"{
+              "specVersion": "1.0",
+              "entries": [
+                {
+                  "identifier": "urn:air:acme.com:agent:test",
+                  "displayName": "Test",
+                  "type": "application/json",
+                  "url": "https://acme.com/test.json",
+                  "trustManifest": {
+                    "identity": "urn:acme:agent:test"
+                  }
+                }
+              ]
+            }"#,
+        )
+        .expect("document should parse");
+
+        let result = validate(&catalog);
+
+        assert!(!result.is_valid);
+        assert!(result.errors.iter().any(|diagnostic| {
+            diagnostic.message
+                == "trustManifest.identity 'urn:acme:agent:test' has no trust domain to align with the entry identifier publisher domain 'acme.com'"
         }));
     }
 

--- a/crates/ai-catalog-validate/src/lib.rs
+++ b/crates/ai-catalog-validate/src/lib.rs
@@ -3,7 +3,9 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use ai_catalog::{AiCatalog, CatalogEntry};
+use ai_catalog::{
+    AiCatalog, CatalogEntry, identity_binds_to_entry, identity_domain, publisher_domain,
+};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
@@ -193,13 +195,14 @@ fn validate_entry(
             errors,
         );
 
-        if trust_manifest.identity != entry.identifier {
+        if identity_binds_to_entry(&entry.identifier, &trust_manifest.identity) == Some(false) {
             push_error(
                 errors,
                 format!("{path}.trustManifest.identity"),
                 format!(
-                    "trustManifest.identity '{}' does not match entry identifier '{}'",
-                    trust_manifest.identity, entry.identifier
+                    "trustManifest.identity domain '{}' does not align with the entry identifier publisher domain '{}'",
+                    identity_domain(&trust_manifest.identity).unwrap_or_default(),
+                    publisher_domain(&entry.identifier).unwrap_or_default()
                 ),
             );
         }
@@ -398,18 +401,18 @@ mod tests {
     }
 
     #[test]
-    fn rejects_mismatched_trust_identity() {
+    fn rejects_misaligned_trust_identity_domain() {
         let catalog = parse_str(
             r#"{
               "specVersion": "1.0",
               "entries": [
                 {
-                  "identifier": "urn:example:test",
+                  "identifier": "urn:air:acme.com:agent:test",
                   "displayName": "Test",
                   "type": "application/json",
-                  "url": "https://example.com/test.json",
+                  "url": "https://acme.com/test.json",
                   "trustManifest": {
-                    "identity": "urn:example:other"
+                    "identity": "did:web:evil.example"
                   }
                 }
               ]
@@ -423,8 +426,33 @@ mod tests {
         assert!(result.errors.iter().any(|diagnostic| {
             diagnostic
                 .message
-                .contains("does not match entry identifier")
+                .contains("does not align with the entry identifier publisher domain")
         }));
+    }
+
+    #[test]
+    fn accepts_trust_identity_aligned_by_domain() {
+        let catalog = parse_str(
+            r#"{
+              "specVersion": "1.0",
+              "entries": [
+                {
+                  "identifier": "urn:air:acme.com:agent:test",
+                  "displayName": "Test",
+                  "type": "application/json",
+                  "url": "https://acme.com/test.json",
+                  "trustManifest": {
+                    "identity": "did:web:acme.com"
+                  }
+                }
+              ]
+            }"#,
+        )
+        .expect("document should parse");
+
+        let result = validate(&catalog);
+
+        assert!(result.is_valid);
     }
 
     #[test]

--- a/crates/ai-catalog/src/identity.rs
+++ b/crates/ai-catalog/src/identity.rs
@@ -1,0 +1,143 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+const URN_AIR_PREFIX: &str = "urn:air:";
+const DID_WEB_PREFIX: &str = "did:web:";
+
+/// Returns the lowercased publisher segment of a
+/// `urn:air:{publisher}:{namespace}:{name}` identifier, or `None` for
+/// non-`urn:air` identifiers.
+pub fn publisher_domain(identifier: &str) -> Option<String> {
+    let rest = strip_prefix_ignore_case(identifier, URN_AIR_PREFIX)?;
+    let publisher = rest.split(':').next().unwrap_or_default();
+
+    if publisher.is_empty() {
+        return None;
+    }
+
+    Some(publisher.to_ascii_lowercase())
+}
+
+/// Returns the lowercased domain of a trust-manifest identity, handling
+/// `urn:air`, `did:web`, and authority-based schemes (`spiffe://`, `https://`,
+/// ...), or `None` when no domain can be determined.
+pub fn identity_domain(identity: &str) -> Option<String> {
+    let id = identity.trim();
+
+    if strip_prefix_ignore_case(id, URN_AIR_PREFIX).is_some() {
+        publisher_domain(id)
+    } else if let Some(rest) = strip_prefix_ignore_case(id, DID_WEB_PREFIX) {
+        did_web_domain(rest)
+    } else {
+        authority_domain(id)
+    }
+}
+
+/// Reports whether a trust-manifest identity's domain aligns with an entry
+/// identifier's publisher domain. Returns `None` when either side carries no
+/// domain, in which case callers must not report a violation.
+pub fn identity_binds_to_entry(identifier: &str, identity: &str) -> Option<bool> {
+    let publisher = publisher_domain(identifier)?;
+    let domain = identity_domain(identity)?;
+
+    Some(publisher == domain)
+}
+
+fn strip_prefix_ignore_case<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    if value.get(..prefix.len())?.eq_ignore_ascii_case(prefix) {
+        value.get(prefix.len()..)
+    } else {
+        None
+    }
+}
+
+fn did_web_domain(rest: &str) -> Option<String> {
+    let mut segment = rest.split(':').next().unwrap_or_default();
+
+    if let Some(index) = segment.to_ascii_lowercase().find("%3a") {
+        segment = &segment[..index];
+    }
+
+    if segment.is_empty() {
+        return None;
+    }
+
+    Some(segment.to_ascii_lowercase())
+}
+
+fn authority_domain(id: &str) -> Option<String> {
+    let (_, authority) = id.split_once("://")?;
+    let authority = authority.split('/').next().unwrap_or_default();
+    let authority = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let authority = authority
+        .rsplit_once(':')
+        .map_or(authority, |(host, _)| host);
+
+    if authority.is_empty() {
+        return None;
+    }
+
+    Some(authority.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{identity_binds_to_entry, identity_domain, publisher_domain};
+
+    #[test]
+    fn publisher_domain_reads_urn_air_publisher() {
+        assert_eq!(
+            publisher_domain("urn:air:Acme.com:agent:finance").as_deref(),
+            Some("acme.com")
+        );
+        assert_eq!(publisher_domain("urn:example:agent"), None);
+        assert_eq!(publisher_domain("urn:air:"), None);
+    }
+
+    #[test]
+    fn identity_domain_handles_supported_schemes() {
+        assert_eq!(
+            identity_domain("did:web:acme.com").as_deref(),
+            Some("acme.com")
+        );
+        assert_eq!(
+            identity_domain("did:web:acme.com%3A8443:user").as_deref(),
+            Some("acme.com")
+        );
+        assert_eq!(
+            identity_domain("urn:air:acme.com:agent:finance").as_deref(),
+            Some("acme.com")
+        );
+        assert_eq!(
+            identity_domain("spiffe://acme.com/workload").as_deref(),
+            Some("acme.com")
+        );
+        assert_eq!(
+            identity_domain("https://user@acme.com:8443/path").as_deref(),
+            Some("acme.com")
+        );
+        assert_eq!(identity_domain("plain-identifier"), None);
+    }
+
+    #[test]
+    fn identity_binds_by_domain_not_exact_match() {
+        assert_eq!(
+            identity_binds_to_entry("urn:air:acme.com:agent:finance", "did:web:acme.com"),
+            Some(true)
+        );
+        assert_eq!(
+            identity_binds_to_entry("urn:air:acme.com:agent:finance", "did:web:evil.example"),
+            Some(false)
+        );
+        assert_eq!(
+            identity_binds_to_entry("urn:example:agent", "did:web:acme.com"),
+            None
+        );
+        assert_eq!(
+            identity_binds_to_entry("urn:air:acme.com:agent:finance", "plain-identifier"),
+            None
+        );
+    }
+}

--- a/crates/ai-catalog/src/identity.rs
+++ b/crates/ai-catalog/src/identity.rs
@@ -34,13 +34,14 @@ pub fn identity_domain(identity: &str) -> Option<String> {
 }
 
 /// Reports whether a trust-manifest identity's domain aligns with an entry
-/// identifier's publisher domain. Returns `None` when either side carries no
-/// domain, in which case callers must not report a violation.
+/// identifier's publisher domain. Returns `None` only when the entry identifier
+/// carries no publisher domain, in which case the binding rule does not apply.
+/// An identity with no determinable domain cannot align, so it reports
+/// `Some(false)` rather than skipping the check.
 pub fn identity_binds_to_entry(identifier: &str, identity: &str) -> Option<bool> {
     let publisher = publisher_domain(identifier)?;
-    let domain = identity_domain(identity)?;
 
-    Some(publisher == domain)
+    Some(identity_domain(identity).as_deref() == Some(publisher.as_str()))
 }
 
 fn strip_prefix_ignore_case<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
@@ -135,8 +136,20 @@ mod tests {
             identity_binds_to_entry("urn:example:agent", "did:web:acme.com"),
             None
         );
+    }
+
+    #[test]
+    fn identity_without_domain_cannot_bind() {
         assert_eq!(
             identity_binds_to_entry("urn:air:acme.com:agent:finance", "plain-identifier"),
+            Some(false)
+        );
+        assert_eq!(
+            identity_binds_to_entry("urn:air:acme.com:agent:finance", "urn:acme:agent:finance"),
+            Some(false)
+        );
+        assert_eq!(
+            identity_binds_to_entry("urn:example:agent", "anything"),
             None
         );
     }

--- a/crates/ai-catalog/src/lib.rs
+++ b/crates/ai-catalog/src/lib.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod error;
+mod identity;
 mod model;
 
 pub use error::{Error, Result};
+pub use identity::{identity_binds_to_entry, identity_domain, publisher_domain};
 pub use model::{
     AiCatalog, Attestation, CatalogEntry, HostInfo, ProvenanceLink, Publisher, TrustManifest,
     TrustSchema,

--- a/crates/ai-catalog/src/model.rs
+++ b/crates/ai-catalog/src/model.rs
@@ -179,7 +179,6 @@ pub struct TrustSchema {
 pub struct Attestation {
     pub r#type: String,
     pub uri: String,
-    pub media_type: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
### Remove the non-spec `Attestation.media_type` field

The CDDL schema defines an attestation as `type`, `uri`, and optional `digest`,
`size`, and `description`. `mediaType` was never part of it. Removed from
`ai-catalog/src/model.rs`.

### Fix digest hex validation

`ParsedDigest::parse` checked that every character was an ASCII hex digit but never
checked how many there were, so `sha256:abc` parsed successfully and produced a
`ParsedDigest` that could never match any real hash.

The algorithm now selects an exact expected hex length (64 / 96 / 128) and the value
is rejected unless it matches.

### Identity binding: exact match to domain alignment

Both `ai-catalog-trust` and `ai-catalog-validate` required
`trust_manifest.identity == entry.identifier`. The spec binds a trust manifest to an
entry by **publisher domain alignment**, not string equality, so the old check
rejected conformant documents: an entry `urn:air:acme.com:agent:finance` signed by
`did:web:acme.com` is valid and was being reported as an error.
