### PR TITLE
ci: add metadata and release crates

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,0 +1,31 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Setup Environment
+description: setup environment to build/test/lint rust applications
+inputs:
+  workspace:
+    description: 'Cargo workspace to cache'
+    required: false
+    default: '.'
+  cache-enabled:
+    description: 'Enable rust cache'
+    required: false
+    default: 'true'
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Rust
+      uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      with:
+        components: rustc, clippy, rustfmt
+        rustflags: ''
+        cache: ${{ inputs.cache-enabled }}
+        cache-workspaces: ${{ inputs.workspace }}
+        cache-on-failure: false
+        # Keep this prefix free of the Cargo.lock hash so a lockfile change
+        # warm-starts from the previous cache instead of cold-starting.
+        cache-shared-key: ${{ runner.os }}-rust
+        cache-all-crates: true
+        cache-bin: false # enabling this clears the bin cache (swatinem cache bug)

--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -1,0 +1,65 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: ci-release-rust
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-crates:
+    name: Release catalog crates
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Run release-plz
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
+        with:
+          command: release
+          manifest_path: ./Cargo.toml
+          config: ./.release-plz.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-crates-pr:
+    name: Release catalog crates - PR
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Run release-plz - PR
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
+        with:
+          command: release-pr
+          manifest_path: ./Cargo.toml
+          config: ./.release-plz.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,30 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+[workspace]
+release_always = false
+release = false
+
+[[package]]
+name = "ai-catalog"
+publish = true
+release = true
+changelog_update = true
+
+[[package]]
+name = "ai-catalog-validate"
+publish = true
+release = true
+changelog_update = true
+
+[[package]]
+name = "ai-catalog-trust"
+publish = true
+release = true
+changelog_update = true
+
+[[package]]
+name = "ai-catalog-oci"
+publish = true
+release = true
+changelog_update = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ rust-version = "1.95"
 version = "0.1.0"
 
 [workspace.dependencies]
+ai-catalog = { path = "crates/ai-catalog", version = "0.1.0" }
+ai-catalog-oci = { path = "crates/ai-catalog-oci", version = "0.1.0" }
+ai-catalog-trust = { path = "crates/ai-catalog-trust", version = "0.1.0" }
+ai-catalog-validate = { path = "crates/ai-catalog-validate", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Rust toolkit for the [AI Catalog specification](https://agent-card.github.io/ai-
 
 | Crate | Description |
 |---|---|
-| `crates/ai-catalog` | Core types (`AiCatalog`, `CatalogEntry`, `HostInfo`, `Publisher`, `TrustManifest`), parse and serialize helpers |
-| `crates/ai-catalog-validate` | Semantic validation and conformance detection |
-| `crates/ai-catalog-trust` | Trust manifest analysis, digest verification, and canonicalization |
-| `crates/ai-catalog-oci` | OCI artifact-set pack/unpack and standard OCI image layout import/export |
+| [`crates/ai-catalog`](crates/ai-catalog/README.md) | Core types (`AiCatalog`, `CatalogEntry`, `HostInfo`, `Publisher`, `TrustManifest`), parse and serialize helpers |
+| [`crates/ai-catalog-validate`](crates/ai-catalog-validate/README.md) | Semantic validation and conformance detection |
+| [`crates/ai-catalog-trust`](crates/ai-catalog-trust/README.md) | Trust manifest analysis, digest verification, and canonicalization |
+| [`crates/ai-catalog-oci`](crates/ai-catalog-oci/README.md) | OCI artifact-set pack/unpack and standard OCI image layout import/export |
 | `crates/ai-catalog-cli` | `ai-catalog` command-line tool |
 
 ### Conformance levels

--- a/crates/ai-catalog-cli/Cargo.toml
+++ b/crates/ai-catalog-cli/Cargo.toml
@@ -3,6 +3,8 @@
 
 [package]
 name = "ai-catalog-cli"
+description = "Command-line tool for inspecting, validating, and packaging AI Catalog documents"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -14,10 +16,10 @@ name = "ai-catalog"
 path = "src/main.rs"
 
 [dependencies]
-ai-catalog = { path = "../ai-catalog" }
-ai-catalog-oci = { path = "../ai-catalog-oci" }
-ai-catalog-trust = { path = "../ai-catalog-trust" }
-ai-catalog-validate = { path = "../ai-catalog-validate" }
+ai-catalog.workspace = true
+ai-catalog-oci.workspace = true
+ai-catalog-trust.workspace = true
+ai-catalog-validate.workspace = true
 async-recursion.workspace = true
 chrono.workspace = true
 clap.workspace = true

--- a/crates/ai-catalog-oci/Cargo.toml
+++ b/crates/ai-catalog-oci/Cargo.toml
@@ -3,6 +3,10 @@
 
 [package]
 name = "ai-catalog-oci"
+description = "Pack and unpack AI Catalog documents as OCI artifacts and image layouts"
+keywords = ["ai", "catalog", "oci", "artifacts", "registry"]
+categories = ["development-tools", "encoding"]
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -10,7 +14,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-ai-catalog = { path = "../ai-catalog" }
+ai-catalog.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/ai-catalog-oci/README.md
+++ b/crates/ai-catalog-oci/README.md
@@ -1,0 +1,22 @@
+# ai-catalog-oci
+
+Pack and unpack [AI Catalog](https://agent-card.github.io/ai-catalog/) documents as OCI
+artifacts and standard OCI image layouts.
+
+Turns a catalog and its referenced entries into a content-addressed artifact set that can
+be pushed to any OCI registry, and reverses the process on the way back.
+
+Note that OCI packaging is not part of the AI Catalog specification; this crate is a
+convenience for distributing catalogs over existing registry infrastructure.
+
+## Usage
+
+```rust
+let catalog = ai_catalog::parse_file("ai-catalog.json")?;
+let artifacts = ai_catalog_oci::pack(&catalog)?;
+let restored = ai_catalog_oci::unpack(&artifacts)?;
+```
+
+## License
+
+Apache-2.0

--- a/crates/ai-catalog-trust/Cargo.toml
+++ b/crates/ai-catalog-trust/Cargo.toml
@@ -3,6 +3,10 @@
 
 [package]
 name = "ai-catalog-trust"
+description = "Trust manifest analysis, digest verification, and canonicalization for AI Catalog documents"
+keywords = ["ai", "catalog", "trust", "attestation", "provenance"]
+categories = ["cryptography"]
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -10,7 +14,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-ai-catalog = { path = "../ai-catalog" }
+ai-catalog.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/ai-catalog-trust/README.md
+++ b/crates/ai-catalog-trust/README.md
@@ -1,0 +1,30 @@
+# ai-catalog-trust
+
+Trust manifest analysis, digest verification, and canonicalization for
+[AI Catalog](https://agent-card.github.io/ai-catalog/) documents.
+
+Inspects the trust manifests attached to catalog entries and host objects, reporting
+findings such as malformed signatures, weak or invalid digests, and trust-manifest
+identities whose domain does not align with the entry's publisher domain.
+
+## Usage
+
+```rust
+let catalog = ai_catalog::parse_file("ai-catalog.json")?;
+let report = ai_catalog_trust::analyze_catalog(&catalog);
+
+for finding in &report.findings {
+    println!("{:?} {}: {}", finding.severity, finding.path, finding.message);
+}
+```
+
+Digests are parsed and verified against the accepted algorithms (SHA-256, SHA-384,
+SHA-512); weaker algorithms are rejected.
+
+```rust
+let matches = ai_catalog_trust::verify_digest("sha256:9f86d081...", bytes)?;
+```
+
+## License
+
+Apache-2.0

--- a/crates/ai-catalog-validate/Cargo.toml
+++ b/crates/ai-catalog-validate/Cargo.toml
@@ -3,6 +3,10 @@
 
 [package]
 name = "ai-catalog-validate"
+description = "Semantic validation and conformance-level detection for AI Catalog documents"
+keywords = ["ai", "catalog", "validation", "conformance", "schema"]
+categories = ["development-tools", "parser-implementations"]
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -10,6 +14,6 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-ai-catalog = { path = "../ai-catalog" }
+ai-catalog.workspace = true
 serde_json.workspace = true
 time.workspace = true

--- a/crates/ai-catalog-validate/README.md
+++ b/crates/ai-catalog-validate/README.md
@@ -1,0 +1,33 @@
+# ai-catalog-validate
+
+Semantic validation and conformance-level detection for
+[AI Catalog](https://agent-card.github.io/ai-catalog/) documents.
+
+Checks the rules a JSON schema cannot express — duplicate identifiers, timestamp formats,
+nesting depth, and trust-manifest identity binding — and reports the conformance level a
+document reaches.
+
+## Conformance levels
+
+| Level | Requirements |
+|---|---|
+| Minimal | `specVersion` plus at least one entry with `identifier` and `type` |
+| Discoverable | Minimal, plus `url` or `data` and `tags` on each entry |
+| Trusted | Discoverable, plus a `trustManifest` with `identity` on each entry |
+
+## Usage
+
+```rust
+let catalog = ai_catalog::parse_file("ai-catalog.json")?;
+let result = ai_catalog_validate::validate(&catalog);
+
+if !result.is_valid {
+    for diagnostic in &result.errors {
+        eprintln!("{}: {}", diagnostic.path, diagnostic.message);
+    }
+}
+```
+
+## License
+
+Apache-2.0

--- a/crates/ai-catalog/Cargo.toml
+++ b/crates/ai-catalog/Cargo.toml
@@ -3,6 +3,10 @@
 
 [package]
 name = "ai-catalog"
+description = "Core types and JSON parsing for the AI Catalog specification"
+keywords = ["ai", "catalog", "agents", "metadata", "discovery"]
+categories = ["parser-implementations", "encoding"]
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/ai-catalog/README.md
+++ b/crates/ai-catalog/README.md
@@ -1,0 +1,31 @@
+# ai-catalog
+
+Core types and JSON parsing for the [AI Catalog specification](https://agent-card.github.io/ai-catalog/).
+
+Provides `AiCatalog`, `CatalogEntry`, `HostInfo`, `Publisher`, `TrustManifest`, and the
+surrounding model types, along with helpers to parse and serialize catalog documents.
+Unrecognized fields are preserved on round-trip.
+
+## Usage
+
+```rust
+let catalog = ai_catalog::parse_file("ai-catalog.json")?;
+
+for entry in catalog.search("finance") {
+    println!("{}", entry.identifier);
+}
+
+let entry = catalog.get_by_id("urn:air:example.com:agent:finance");
+```
+
+## Related crates
+
+| Crate | Purpose |
+|---|---|
+| [`ai-catalog-validate`](https://crates.io/crates/ai-catalog-validate) | Semantic validation and conformance levels |
+| [`ai-catalog-trust`](https://crates.io/crates/ai-catalog-trust) | Trust manifest analysis and digest verification |
+| [`ai-catalog-oci`](https://crates.io/crates/ai-catalog-oci) | OCI artifact packaging |
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
This PR adds metadata to the crates and prepares the release of them to crates.io.
The CLI package is not released on purpose, because it will be moved out to: https://github.com/agntcy/ai-catalog-cli.
The prerequisite of moving out the CLI is that the other crates that it depends on are on crates.io.