### PR TITLE
chore: release v0.1.0

### DIFF
--- a/crates/ai-catalog-oci/CHANGELOG.md
+++ b/crates/ai-catalog-oci/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-oci-v0.1.0) - 2026-08-04
+
+### Added
+
+- *(cli)* Phase 2 refactor — consumer commands, OCI consumer path, test coverage, docs ([#4](https://github.com/agntcy/ai-catalog-rust/pull/4))
+- add cosign verification artifacts to OCI layouts
+- bootstrap ai-catalog-rust toolkit
+
+### Fixed
+
+- resolve CI lint failures
+
+### Other
+
+- add metadata and release crates ([#10](https://github.com/agntcy/ai-catalog-rust/pull/10))

--- a/crates/ai-catalog-trust/CHANGELOG.md
+++ b/crates/ai-catalog-trust/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-trust-v0.1.0) - 2026-08-04
+
+### Added
+
+- *(cli)* Phase 2 refactor — consumer commands, OCI consumer path, test coverage, docs ([#4](https://github.com/agntcy/ai-catalog-rust/pull/4))
+- bootstrap ai-catalog-rust toolkit
+
+### Fixed
+
+- bugs and spec conformance ([#9](https://github.com/agntcy/ai-catalog-rust/pull/9))
+
+### Other
+
+- add metadata and release crates ([#10](https://github.com/agntcy/ai-catalog-rust/pull/10))

--- a/crates/ai-catalog-validate/CHANGELOG.md
+++ b/crates/ai-catalog-validate/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-validate-v0.1.0) - 2026-08-04
+
+### Added
+
+- *(cli)* Phase 2 refactor — consumer commands, OCI consumer path, test coverage, docs ([#4](https://github.com/agntcy/ai-catalog-rust/pull/4))
+- bootstrap ai-catalog-rust toolkit
+
+### Fixed
+
+- bugs and spec conformance ([#9](https://github.com/agntcy/ai-catalog-rust/pull/9))
+
+### Other
+
+- add metadata and release crates ([#10](https://github.com/agntcy/ai-catalog-rust/pull/10))

--- a/crates/ai-catalog/CHANGELOG.md
+++ b/crates/ai-catalog/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-v0.1.0) - 2026-08-04
+
+### Added
+
+- *(ai-catalog)* add get_by_id, search, and search_by_regex to AiCatalog ([#6](https://github.com/agntcy/ai-catalog-rust/pull/6))
+- *(cli)* Phase 2 refactor — consumer commands, OCI consumer path, test coverage, docs ([#4](https://github.com/agntcy/ai-catalog-rust/pull/4))
+- bootstrap ai-catalog-rust toolkit
+
+### Fixed
+
+- bugs and spec conformance ([#9](https://github.com/agntcy/ai-catalog-rust/pull/9))
+
+### Other
+
+- add metadata and release crates ([#10](https://github.com/agntcy/ai-catalog-rust/pull/10))


### PR DESCRIPTION



## 🤖 New release

* `ai-catalog`: 0.1.0
* `ai-catalog-validate`: 0.1.0
* `ai-catalog-trust`: 0.1.0
* `ai-catalog-oci`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `ai-catalog`

<blockquote>

## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-v0.1.0) - 2026-08-04

### Added

- *(ai-catalog)* add get_by_id, search, and search_by_regex to AiCatalog ([#6](https://github.com/agntcy/ai-catalog-rust/pull/6))
- *(cli)* Phase 2 refactor — consumer commands, OCI consumer path, test coverage, docs ([#4](https://github.com/agntcy/ai-catalog-rust/pull/4))
- bootstrap ai-catalog-rust toolkit

### Fixed

- bugs and spec conformance ([#9](https://github.com/agntcy/ai-catalog-rust/pull/9))

### Other

- add metadata and release crates ([#10](https://github.com/agntcy/ai-catalog-rust/pull/10))
</blockquote>

## `ai-catalog-validate`

<blockquote>

## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-validate-v0.1.0) - 2026-08-04

### Added

- *(cli)* Phase 2 refactor — consumer commands, OCI consumer path, test coverage, docs ([#4](https://github.com/agntcy/ai-catalog-rust/pull/4))
- bootstrap ai-catalog-rust toolkit

### Fixed

- bugs and spec conformance ([#9](https://github.com/agntcy/ai-catalog-rust/pull/9))

### Other

- add metadata and release crates ([#10](https://github.com/agntcy/ai-catalog-rust/pull/10))
</blockquote>

## `ai-catalog-trust`

<blockquote>

## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-trust-v0.1.0) - 2026-08-04

### Added

- *(cli)* Phase 2 refactor — consumer commands, OCI consumer path, test coverage, docs ([#4](https://github.com/agntcy/ai-catalog-rust/pull/4))
- bootstrap ai-catalog-rust toolkit

### Fixed

- bugs and spec conformance ([#9](https://github.com/agntcy/ai-catalog-rust/pull/9))

### Other

- add metadata and release crates ([#10](https://github.com/agntcy/ai-catalog-rust/pull/10))
</blockquote>

## `ai-catalog-oci`

<blockquote>

## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-oci-v0.1.0) - 2026-08-04

### Added

- *(cli)* Phase 2 refactor — consumer commands, OCI consumer path, test coverage, docs ([#4](https://github.com/agntcy/ai-catalog-rust/pull/4))
- add cosign verification artifacts to OCI layouts
- bootstrap ai-catalog-rust toolkit

### Fixed

- resolve CI lint failures

### Other

- add metadata and release crates ([#10](https://github.com/agntcy/ai-catalog-rust/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Keep a Changelog-formatted release notes for the initial 0.1.0 release.
  - Documented CLI improvements, toolkit bootstrapping, verification support, metadata and release enhancements, bug fixes, and specification-conformance updates.
  - Added an Unreleased section to track upcoming changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->