### PR TITLE
chore: add sdk admins as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default ownership for the repository.
-* @agntcy/rustaceans
+* @agntcy/rustaceans @agntcy/sdk-admins


### PR DESCRIPTION
Add SDK admins as codeowners.