### PR TITLE
feat: align model, validation, and trust analysis with the AI Catalog specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,10 @@ ai-catalog = { path = "crates/ai-catalog", version = "0.1.0" }
 ai-catalog-oci = { path = "crates/ai-catalog-oci", version = "0.1.0" }
 ai-catalog-trust = { path = "crates/ai-catalog-trust", version = "0.1.0" }
 ai-catalog-validate = { path = "crates/ai-catalog-validate", version = "0.1.0" }
+base64 = "0.22"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
+serde_jcs = "0.2"
 serde_json = "1.0"
 sha2 = "0.10"
 thiserror = "2.0"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ai-catalog-rust
 
-Rust libraries for the [AI Catalog specification](https://agent-card.github.io/ai-catalog/).
+Rust libraries for the [AI Catalog specification](https://ai-catalog.io/).
 
 | Resource | Link |
 |---|---|
-| Specification | <https://agent-card.github.io/ai-catalog/> |
+| Specification | <https://ai-catalog.io/> |
 | Upstream repository | <https://github.com/Agent-Card/ai-catalog> |
 | Command-line tool | <https://github.com/agntcy/ai-catalog-cli> |
 
@@ -29,17 +29,17 @@ these crates from crates.io.
 
 | Level | Requirements |
 |---|---|
-| **Minimal** | `specVersion` + at least one entry with `identifier` and `type` |
-| **Discoverable** | Minimal + `url` or `data` on each entry + `tags` |
-| **Trusted** | Discoverable + `trustManifest` with `identity` on each entry |
+| **Minimal** | `specVersion`, and every entry carrying `identifier`, `type`, and exactly one of `url` or `data` |
+| **Discoverable** | Minimal + a `host` object identifying the catalog operator |
+| **Trusted** | Discoverable + every `trustManifest` in the document signed, with a `subject` and `issuedAt` |
 
 ## Usage
 
 ```toml
 [dependencies]
-ai-catalog = "0.1"
-ai-catalog-validate = "0.1"
-ai-catalog-trust = "0.1"
+ai-catalog = "0.2"
+ai-catalog-validate = "0.2"
+ai-catalog-trust = "0.2"
 ```
 
 Parse a catalog and look up entries. Unrecognized fields survive a round-trip:

--- a/crates/ai-catalog-oci/README.md
+++ b/crates/ai-catalog-oci/README.md
@@ -1,6 +1,6 @@
 # ai-catalog-oci
 
-Pack and unpack [AI Catalog](https://agent-card.github.io/ai-catalog/) documents as OCI
+Pack and unpack [AI Catalog](https://ai-catalog.io/) documents as OCI
 artifacts and standard OCI image layouts.
 
 Turns a catalog and its referenced entries into a content-addressed artifact set that can

--- a/crates/ai-catalog-oci/src/lib.rs
+++ b/crates/ai-catalog-oci/src/lib.rs
@@ -139,7 +139,7 @@ struct EntryConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     updated_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    metadata: Option<BTreeMap<String, Value>>,
+    extensions: Option<BTreeMap<String, Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     publisher: Option<Publisher>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -267,10 +267,15 @@ pub fn unpack_catalog(artifacts: &OciArtifactSet) -> Result<AiCatalog> {
         .cloned()
         .ok_or(Error::MissingSpecVersion)?;
     let host = annotations_json::<HostInfo>(&artifacts.index.annotations, "ai-catalog.host")?;
-    let metadata = annotations_json::<BTreeMap<String, Value>>(
+    let extensions = annotations_json::<BTreeMap<String, Value>>(
         &artifacts.index.annotations,
-        "ai-catalog.metadata",
+        "ai-catalog.extensions",
     )?;
+    let signature = artifacts
+        .index
+        .annotations
+        .get("ai-catalog.signature")
+        .cloned();
     let extra_fields = annotations_json::<BTreeMap<String, Value>>(
         &artifacts.index.annotations,
         "ai-catalog.extraFields",
@@ -336,7 +341,7 @@ pub fn unpack_catalog(artifacts: &OciArtifactSet) -> Result<AiCatalog> {
             publisher: config.publisher,
             trust_manifest,
             updated_at: config.updated_at,
-            metadata: config.metadata,
+            extensions: config.extensions,
             extra_fields: config.extra_fields,
         });
     }
@@ -345,7 +350,8 @@ pub fn unpack_catalog(artifacts: &OciArtifactSet) -> Result<AiCatalog> {
         spec_version,
         host,
         entries,
-        metadata,
+        signature,
+        extensions,
         extra_fields,
     })
 }
@@ -596,11 +602,15 @@ fn catalog_annotations(catalog: &AiCatalog) -> Result<BTreeMap<String, String>> 
         annotations.insert("ai-catalog.host".to_owned(), serde_json::to_string(host)?);
     }
 
-    if let Some(metadata) = &catalog.metadata {
+    if let Some(extensions) = &catalog.extensions {
         annotations.insert(
-            "ai-catalog.metadata".to_owned(),
-            serde_json::to_string(metadata)?,
+            "ai-catalog.extensions".to_owned(),
+            serde_json::to_string(extensions)?,
         );
+    }
+
+    if let Some(signature) = &catalog.signature {
+        annotations.insert("ai-catalog.signature".to_owned(), signature.clone());
     }
 
     if !catalog.extra_fields.is_empty() {
@@ -833,7 +843,7 @@ impl From<&CatalogEntry> for EntryConfig {
             tags: entry.tags.clone(),
             version: entry.version.clone(),
             updated_at: entry.updated_at.clone(),
-            metadata: entry.metadata.clone(),
+            extensions: entry.extensions.clone(),
             publisher: entry.publisher.clone(),
             url: entry.url.clone(),
             extra_fields: entry.extra_fields.clone(),
@@ -882,8 +892,8 @@ mod tests {
         let catalog = parse_str(
             r#"{
 			  "specVersion": "1.0",
-			  "metadata": {
-				"scope": "test"
+			  "extensions": {
+				"com.example.scope": "test"
 			  },
 			  "entries": [
 				{
@@ -948,8 +958,8 @@ mod tests {
                 "host": {
                     "displayName": "Example Host"
                 },
-                "metadata": {
-                    "scope": "demo"
+                "extensions": {
+                    "com.example.scope": "demo"
                 },
                 "entries": [
                     {
@@ -972,7 +982,7 @@ mod tests {
             artifacts
                 .index
                 .annotations
-                .contains_key("ai-catalog.metadata")
+                .contains_key("ai-catalog.extensions")
         );
     }
 

--- a/crates/ai-catalog-trust/Cargo.toml
+++ b/crates/ai-catalog-trust/Cargo.toml
@@ -15,6 +15,9 @@ rust-version.workspace = true
 
 [dependencies]
 ai-catalog.workspace = true
+base64.workspace = true
+serde_jcs.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+time.workspace = true

--- a/crates/ai-catalog-trust/README.md
+++ b/crates/ai-catalog-trust/README.md
@@ -1,11 +1,22 @@
 # ai-catalog-trust
 
 Trust manifest analysis, digest verification, and canonicalization for
-[AI Catalog](https://agent-card.github.io/ai-catalog/) documents.
+[AI Catalog](https://ai-catalog.io/) documents.
 
 Inspects the trust manifests attached to catalog entries and host objects, reporting
-findings such as malformed signatures, weak or invalid digests, and trust-manifest
-identities whose domain does not align with the entry's publisher domain.
+findings such as malformed signatures, signature algorithms that cannot establish
+third-party trust, signatures that commit to no artifact, weak or invalid digests, and
+trust-manifest identities whose domain does not align with the entry's publisher domain.
+The document-level `signature` is held to the same algorithm constraints.
+
+Analysis descends into catalogs embedded in an entry's `data`, up to the specification's
+RECOMMENDED nesting depth of 4. A finding's `path` records where it was found, for example
+`catalog.entries[0].data.entries[2].trustManifest`.
+
+Canonicalization follows [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) (JCS), so the
+payload a signature covers is byte-identical to the one produced by other conforming
+implementations. `canonicalize_trust_manifest` and `canonicalize_catalog` produce the
+payloads for manifest-level and document-level signatures respectively.
 
 ## Usage
 

--- a/crates/ai-catalog-trust/src/lib.rs
+++ b/crates/ai-catalog-trust/src/lib.rs
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use ai_catalog::{
-    AiCatalog, CatalogEntry, HostInfo, TrustManifest, identity_binds_to_entry, identity_domain,
-    publisher_domain,
+    AiCatalog, CatalogEntry, HostInfo, Subject, TrustManifest, identity_binds_to_entry,
+    identity_domain, publisher_domain,
 };
-use serde_json::{Map, Value};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD;
+use serde_json::Value;
 use sha2::{Digest as _, Sha256, Sha384, Sha512};
 use thiserror::Error;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -53,6 +57,7 @@ pub struct CatalogTrustReport {
     pub findings: Vec<Finding>,
     pub host: Option<ManifestReport>,
     pub entries: Vec<ManifestReport>,
+    pub has_signature: bool,
 }
 
 const SHA256_HEX_LEN: usize = 64;
@@ -124,7 +129,17 @@ pub fn canonicalize_trust_manifest(manifest: &TrustManifest) -> Result<String> {
         object.remove("signature");
     }
 
-    serde_json::to_string(&sort_value(value)).map_err(Error::from)
+    serde_jcs::to_string(&value).map_err(Error::from)
+}
+
+pub fn canonicalize_catalog(catalog: &AiCatalog) -> Result<String> {
+    let mut value = serde_json::to_value(catalog)?;
+
+    if let Value::Object(object) = &mut value {
+        object.remove("signature");
+    }
+
+    serde_jcs::to_string(&value).map_err(Error::from)
 }
 
 pub fn verify_digest(expected_digest: &str, bytes: &[u8]) -> Result<bool> {
@@ -132,35 +147,85 @@ pub fn verify_digest(expected_digest: &str, bytes: &[u8]) -> Result<bool> {
 }
 
 pub fn analyze_catalog(catalog: &AiCatalog) -> CatalogTrustReport {
-    let host = catalog.host.as_ref().and_then(analyze_host_manifest);
-    let entries = catalog
-        .entries
-        .iter()
-        .enumerate()
-        .filter_map(|(index, entry)| analyze_entry_manifest(entry, index))
-        .collect::<Vec<_>>();
+    let mut host = None;
+    let mut entries = Vec::new();
 
-    let findings = host
-        .iter()
-        .flat_map(|report| report.findings.iter().cloned())
-        .chain(
-            entries
-                .iter()
-                .flat_map(|report| report.findings.iter().cloned()),
-        )
-        .collect();
+    analyze_catalog_at(catalog, "catalog", 1, &mut host, &mut entries);
+
+    let mut findings = Vec::new();
+
+    if let Some(signature) = &catalog.signature {
+        analyze_signature_algorithm("catalog.signature", signature, &mut findings);
+    }
+
+    findings.extend(
+        host.iter()
+            .flat_map(|report: &ManifestReport| report.findings.iter().cloned())
+            .chain(
+                entries
+                    .iter()
+                    .flat_map(|report: &ManifestReport| report.findings.iter().cloned()),
+            ),
+    );
 
     CatalogTrustReport {
         findings,
         host,
         entries,
+        has_signature: catalog.signature.is_some(),
     }
 }
 
-fn analyze_host_manifest(host: &HostInfo) -> Option<ManifestReport> {
+const MAX_NESTING_DEPTH: usize = 4;
+
+fn analyze_catalog_at(
+    catalog: &AiCatalog,
+    path: &str,
+    depth: usize,
+    root_host: &mut Option<ManifestReport>,
+    entries: &mut Vec<ManifestReport>,
+) {
+    if let Some(host) = &catalog.host
+        && let Some(report) = analyze_host_manifest(host, &format!("{path}.host.trustManifest"))
+    {
+        if depth == 1 {
+            *root_host = Some(report);
+        } else {
+            entries.push(report);
+        }
+    }
+
+    for (index, entry) in catalog.entries.iter().enumerate() {
+        let entry_path = format!("{path}.entries[{index}]");
+
+        if let Some(report) = analyze_entry_manifest(entry, &entry_path) {
+            entries.push(report);
+        }
+
+        if depth >= MAX_NESTING_DEPTH || !entry.is_nested_catalog() {
+            continue;
+        }
+
+        let Some(data) = &entry.data else {
+            continue;
+        };
+
+        if let Ok(nested) = serde_json::from_value::<AiCatalog>(data.clone()) {
+            analyze_catalog_at(
+                &nested,
+                &format!("{entry_path}.data"),
+                depth + 1,
+                root_host,
+                entries,
+            );
+        }
+    }
+}
+
+fn analyze_host_manifest(host: &HostInfo, path: &str) -> Option<ManifestReport> {
     let manifest = host.trust_manifest.as_ref()?;
     let mut findings = Vec::new();
-    let path = "catalog.host.trustManifest".to_owned();
+    let path = path.to_owned();
 
     if manifest.identity.find(':').is_none() {
         findings.push(Finding {
@@ -195,9 +260,9 @@ fn analyze_host_manifest(host: &HostInfo) -> Option<ManifestReport> {
     })
 }
 
-fn analyze_entry_manifest(entry: &CatalogEntry, index: usize) -> Option<ManifestReport> {
+fn analyze_entry_manifest(entry: &CatalogEntry, entry_path: &str) -> Option<ManifestReport> {
     let manifest = entry.trust_manifest.as_ref()?;
-    let path = format!("catalog.entries[{index}].trustManifest");
+    let path = format!("{entry_path}.trustManifest");
     let mut findings = Vec::new();
 
     if identity_binds_to_entry(&entry.identifier, &manifest.identity) == Some(false) {
@@ -240,15 +305,9 @@ fn analyze_entry_manifest(entry: &CatalogEntry, index: usize) -> Option<Manifest
 }
 
 fn analyze_manifest_contents(path: &str, manifest: &TrustManifest, findings: &mut Vec<Finding>) {
-    if let Some(signature) = &manifest.signature
-        && !looks_like_detached_jws(signature)
-    {
-        findings.push(Finding {
-            severity: Severity::Error,
-            path: format!("{path}.signature"),
-            message: "signature must use detached JWS compact serialization".to_owned(),
-        });
-    }
+    analyze_signature(path, manifest, findings);
+    analyze_subject(path, manifest.subject.as_ref(), findings);
+    analyze_validity_window(path, manifest, findings);
 
     if let Some(trust_schema) = &manifest.trust_schema {
         if trust_schema.identifier.is_empty() {
@@ -321,6 +380,154 @@ fn analyze_manifest_contents(path: &str, manifest: &TrustManifest, findings: &mu
     }
 }
 
+const ALLOWED_JWS_ALGORITHMS: [&str; 6] = ["ES256", "ES384", "EdDSA", "PS256", "PS384", "RS256"];
+
+fn analyze_signature(path: &str, manifest: &TrustManifest, findings: &mut Vec<Finding>) {
+    let Some(signature) = &manifest.signature else {
+        return;
+    };
+
+    if !looks_like_detached_jws(signature) {
+        findings.push(Finding {
+            severity: Severity::Error,
+            path: format!("{path}.signature"),
+            message: "signature must use detached JWS compact serialization".to_owned(),
+        });
+
+        return;
+    }
+
+    if manifest.subject.is_none() {
+        findings.push(Finding {
+            severity: Severity::Error,
+            path: format!("{path}.subject"),
+            message: "a signed trust manifest must carry a subject binding it to the artifact"
+                .to_owned(),
+        });
+    }
+
+    if manifest.issued_at.is_none() {
+        findings.push(Finding {
+            severity: Severity::Error,
+            path: format!("{path}.issuedAt"),
+            message: "a signed trust manifest must carry an issuedAt timestamp".to_owned(),
+        });
+    }
+
+    analyze_signature_algorithm(&format!("{path}.signature"), signature, findings);
+}
+
+fn analyze_signature_algorithm(path: &str, signature: &str, findings: &mut Vec<Finding>) {
+    let Some(algorithm) = jws_algorithm(signature) else {
+        findings.push(Finding {
+            severity: Severity::Error,
+            path: path.to_owned(),
+            message: "signature JWS header must be base64url-encoded JSON declaring an 'alg'"
+                .to_owned(),
+        });
+
+        return;
+    };
+
+    if is_forbidden_jws_algorithm(&algorithm) {
+        findings.push(Finding {
+            severity: Severity::Error,
+            path: path.to_owned(),
+            message: format!(
+                "signature algorithm '{algorithm}' must be rejected; a trust manifest requires an \
+                 asymmetric signature"
+            ),
+        });
+    } else if !ALLOWED_JWS_ALGORITHMS.contains(&algorithm.as_str()) {
+        findings.push(Finding {
+            severity: Severity::Warning,
+            path: path.to_owned(),
+            message: format!(
+                "signature algorithm '{algorithm}' is outside the specification allowlist ({})",
+                ALLOWED_JWS_ALGORITHMS.join(", ")
+            ),
+        });
+    }
+}
+
+fn is_forbidden_jws_algorithm(algorithm: &str) -> bool {
+    let normalized = algorithm.to_ascii_uppercase();
+
+    normalized == "NONE" || normalized.starts_with("HS")
+}
+
+fn jws_algorithm(signature: &str) -> Option<String> {
+    let encoded = signature.split('.').next()?;
+    let header = BASE64_URL_SAFE_NO_PAD.decode(encoded).ok()?;
+    let parsed: Value = serde_json::from_slice(&header).ok()?;
+
+    match parsed.get("alg")?.as_str()? {
+        "" => None,
+        algorithm => Some(algorithm.to_owned()),
+    }
+}
+
+fn analyze_subject(path: &str, subject: Option<&Subject>, findings: &mut Vec<Finding>) {
+    let Some(subject) = subject else {
+        return;
+    };
+
+    if subject.r#type.is_empty() {
+        findings.push(Finding {
+            severity: Severity::Error,
+            path: format!("{path}.subject.type"),
+            message: "subject type must not be empty".to_owned(),
+        });
+    }
+
+    if subject.digest.is_empty() {
+        findings.push(Finding {
+            severity: Severity::Error,
+            path: format!("{path}.subject.digest"),
+            message: "subject digest must not be empty".to_owned(),
+        });
+
+        return;
+    }
+
+    analyze_digest_field(&subject.digest, &format!("{path}.subject.digest"), findings);
+}
+
+fn analyze_validity_window(path: &str, manifest: &TrustManifest, findings: &mut Vec<Finding>) {
+    if let Some(issued_at) = &manifest.issued_at
+        && OffsetDateTime::parse(issued_at, &Rfc3339).is_err()
+    {
+        findings.push(invalid_timestamp(&format!("{path}.issuedAt"), issued_at));
+    }
+
+    let Some(expires_at) = &manifest.expires_at else {
+        return;
+    };
+
+    match OffsetDateTime::parse(expires_at, &Rfc3339) {
+        Ok(parsed) => {
+            if parsed < OffsetDateTime::now_utc() {
+                findings.push(Finding {
+                    severity: Severity::Warning,
+                    path: format!("{path}.expiresAt"),
+                    message: format!(
+                        "trust manifest expired at {expires_at} and SHOULD be rejected"
+                    ),
+                });
+            }
+        }
+        Err(_) => findings.push(invalid_timestamp(&format!("{path}.expiresAt"), expires_at)),
+    }
+}
+
+fn invalid_timestamp(path: &str, value: &str) -> Finding {
+    Finding {
+        severity: Severity::Error,
+        path: path.to_owned(),
+        message: format!("'{value}' is not a valid RFC 3339 datetime"),
+    }
+}
+
 fn analyze_digest_field(value: &str, path: &str, findings: &mut Vec<Finding>) {
     if let Err(error) = ParsedDigest::parse(value) {
         findings.push(Finding {
@@ -342,24 +549,6 @@ fn looks_like_detached_jws(signature: &str) -> bool {
     }
 }
 
-fn sort_value(value: Value) -> Value {
-    match value {
-        Value::Array(values) => Value::Array(values.into_iter().map(sort_value).collect()),
-        Value::Object(object) => {
-            let mut sorted = object.into_iter().collect::<Vec<_>>();
-            sorted.sort_by(|left, right| left.0.cmp(&right.0));
-
-            let mut map = Map::new();
-            for (key, value) in sorted {
-                map.insert(key, sort_value(value));
-            }
-
-            Value::Object(map)
-        }
-        other => other,
-    }
-}
-
 fn digest_hex(bytes: &[u8]) -> String {
     let mut hex = String::with_capacity(bytes.len() * 2);
 
@@ -377,9 +566,335 @@ mod tests {
     use ai_catalog::parse_str;
 
     use super::{
-        CatalogTrustReport, Error, ParsedDigest, Severity, analyze_catalog,
+        CatalogTrustReport, Error, ParsedDigest, Severity, analyze_catalog, canonicalize_catalog,
         canonicalize_trust_manifest, verify_digest,
     };
+
+    #[test]
+    fn canonicalization_sorts_keys_by_utf16_code_unit() {
+        let manifest = parse_str(&format!(
+            r#"{{
+              "specVersion": "1.0",
+              "entries": [
+                {{
+                  "identifier": "urn:example:keys",
+                  "type": "application/json",
+                  "url": "https://example.com/a.json",
+                  "trustManifest": {{
+                    "identity": "urn:example:keys",
+                    "extensions": {{ "{bmp}": 1, "{non_bmp}": 2 }}
+                  }}
+                }}
+              ]
+            }}"#,
+            bmp = '\u{e000}',
+            non_bmp = '\u{10000}'
+        ))
+        .expect("document should parse");
+
+        let canonical = canonicalize_trust_manifest(
+            manifest.entries[0]
+                .trust_manifest
+                .as_ref()
+                .expect("manifest should exist"),
+        )
+        .expect("manifest should canonicalize");
+
+        let non_bmp = canonical.find('\u{10000}').expect("non-BMP key is present");
+        let bmp = canonical.find('\u{e000}').expect("BMP key is present");
+
+        assert!(
+            non_bmp < bmp,
+            "non-BMP key must sort first, got: {canonical}"
+        );
+    }
+
+    #[test]
+    fn canonicalization_uses_ecmascript_number_formatting() {
+        let manifest = parse_str(
+            r#"{
+              "specVersion": "1.0",
+              "entries": [
+                {
+                  "identifier": "urn:example:numbers",
+                  "type": "application/json",
+                  "url": "https://example.com/a.json",
+                  "trustManifest": {
+                    "identity": "urn:example:numbers",
+                    "extensions": { "com.example.big": 1e21 }
+                  }
+                }
+              ]
+            }"#,
+        )
+        .expect("document should parse");
+
+        let canonical = canonicalize_trust_manifest(
+            manifest.entries[0]
+                .trust_manifest
+                .as_ref()
+                .expect("manifest should exist"),
+        )
+        .expect("manifest should canonicalize");
+
+        assert!(
+            canonical.contains("1e+21"),
+            "expected ECMAScript number form, got: {canonical}"
+        );
+    }
+
+    #[test]
+    fn rejects_signatures_that_cannot_establish_third_party_trust() {
+        for (algorithm, signature) in [
+            ("none", "eyJhbGciOiJub25lIn0..c2ln"),
+            ("HS256", "eyJhbGciOiJIUzI1NiJ9..c2ln"),
+        ] {
+            let report = analyze(&format!(
+                r#"{{
+                  "specVersion": "1.0",
+                  "entries": [
+                    {{
+                      "identifier": "urn:example:weak",
+                      "type": "application/json",
+                      "url": "https://example.com/a.json",
+                      "trustManifest": {{
+                        "identity": "urn:example:weak",
+                        "issuedAt": "2026-01-01T00:00:00Z",
+                        "signature": "{signature}",
+                        "subject": {{
+                          "type": "application/json",
+                          "digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+                        }}
+                      }}
+                    }}
+                  ]
+                }}"#
+            ));
+
+            assert!(
+                report.findings.iter().any(|finding| {
+                    finding.severity == Severity::Error
+                        && finding.message.contains("must be rejected")
+                }),
+                "expected {algorithm} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn analyzes_manifests_inside_nested_catalogs() {
+        let manifest = r#"{
+            "identity": "did:web:acme.com",
+            "signature": "eyJhbGciOiJub25lIn0..c2ln",
+            "issuedAt": "2026-01-01T00:00:00Z",
+            "subject": {"type": "application/parquet", "digest": "md5:abc", "url": "https://acme.com/d.parquet"}
+        }"#;
+        let report = analyze(&format!(
+            r#"{{"specVersion":"1.0","entries":[
+                {{"identifier":"urn:air:acme.com:catalog:c","type":"application/ai-catalog+json","data":{{
+                    "specVersion":"1.0","entries":[
+                        {{"identifier":"urn:air:acme.com:data:d","type":"application/parquet","url":"https://acme.com/d.parquet","trustManifest":{manifest}}}
+                    ]}}}}
+            ]}}"#
+        ));
+
+        assert!(
+            report.findings.iter().any(|finding| {
+                finding.severity == Severity::Error && finding.message.contains("'none'")
+            }),
+            "nested forbidden algorithm went unreported: {:?}",
+            report.findings
+        );
+        assert!(
+            report.findings.iter().any(|finding| {
+                finding.severity == Severity::Error
+                    && finding.message.contains("weaker than SHA-256")
+            }),
+            "nested weak digest went unreported: {:?}",
+            report.findings
+        );
+        assert!(
+            report
+                .entries
+                .iter()
+                .any(|entry| entry.path == "catalog.entries[0].data.entries[0].trustManifest"),
+            "nested manifest missing from the report: {:?}",
+            report.entries.iter().map(|e| &e.path).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn stops_descending_at_the_recommended_depth_limit() {
+        let mut document = r#"{"specVersion":"1.0","entries":[{"identifier":"urn:air:acme.com:data:d","type":"application/parquet","url":"https://acme.com/d.parquet","trustManifest":{"identity":"did:web:acme.com","signature":"eyJhbGciOiJub25lIn0..c2ln","issuedAt":"2026-01-01T00:00:00Z","subject":{"type":"application/parquet","digest":"sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08","url":"https://acme.com/d.parquet"}}}]}"#.to_owned();
+
+        for _ in 0..5 {
+            document = format!(
+                r#"{{"specVersion":"1.0","entries":[{{"identifier":"urn:air:acme.com:catalog:c","type":"application/ai-catalog+json","data":{document}}}]}}"#
+            );
+        }
+
+        let report = analyze(&document);
+
+        assert!(
+            report.findings.is_empty(),
+            "recursion passed the depth limit: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn analyzes_the_catalog_level_signature() {
+        let report = analyze(
+            r#"{
+              "specVersion": "1.0",
+              "entries": [],
+              "signature": "eyJhbGciOiJIUzI1NiJ9..c2ln"
+            }"#,
+        );
+
+        assert!(report.has_signature);
+        assert!(
+            report.findings.iter().any(|finding| {
+                finding.severity == Severity::Error && finding.path == "catalog.signature"
+            }),
+            "catalog signature not analyzed: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn canonicalizes_catalog_without_signature() {
+        let catalog = parse_str(
+            r#"{"specVersion":"1.0","entries":[],"signature":"eyJhbGciOiJFUzI1NiJ9..c2ln"}"#,
+        )
+        .expect("document should parse");
+
+        let canonical = canonicalize_catalog(&catalog).expect("canonicalizes");
+
+        assert!(!canonical.contains("signature"));
+        assert_eq!(canonical, r#"{"entries":[],"specVersion":"1.0"}"#);
+    }
+
+    #[test]
+    fn reports_malformed_and_expired_manifest_timestamps() {
+        let report = analyze(
+            r#"{
+              "specVersion": "1.0",
+              "entries": [
+                {
+                  "identifier": "urn:example:bad-issued",
+                  "type": "application/json",
+                  "url": "https://example.com/a.json",
+                  "trustManifest": {
+                    "identity": "urn:example:bad-issued",
+                    "issuedAt": "not-a-date",
+                    "expiresAt": "2020-01-01T00:00:00Z"
+                  }
+                }
+              ]
+            }"#,
+        );
+
+        assert!(report.findings.iter().any(|finding| {
+            finding.severity == Severity::Error
+                && finding.message.contains("not a valid RFC 3339 datetime")
+        }));
+        assert!(report.findings.iter().any(|finding| {
+            finding.severity == Severity::Warning && finding.message.contains("expired at")
+        }));
+    }
+
+    #[test]
+    fn compares_timestamps_as_instants_not_strings() {
+        let report = analyze(
+            r#"{
+              "specVersion": "1.0",
+              "entries": [
+                {
+                  "identifier": "urn:example:offset",
+                  "type": "application/json",
+                  "url": "https://example.com/a.json",
+                  "trustManifest": {
+                    "identity": "urn:example:offset",
+                    "issuedAt": "2030-01-01T12:00:00Z",
+                    "expiresAt": "2030-01-01T02:00:00-11:00"
+                  }
+                }
+              ]
+            }"#,
+        );
+
+        assert!(
+            report.findings.is_empty(),
+            "unexpected findings: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn warns_on_algorithms_outside_the_allowlist() {
+        let report = analyze(
+            r#"{
+              "specVersion": "1.0",
+              "entries": [
+                {
+                  "identifier": "urn:example:odd",
+                  "type": "application/json",
+                  "url": "https://example.com/a.json",
+                  "trustManifest": {
+                    "identity": "urn:example:odd",
+                    "issuedAt": "2026-01-01T00:00:00Z",
+                    "signature": "eyJhbGciOiJSUzUxMiJ9..c2ln",
+                    "subject": {
+                      "type": "application/json",
+                      "digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+                    }
+                  }
+                }
+              ]
+            }"#,
+        );
+
+        assert!(report.findings.iter().any(|finding| {
+            finding.severity == Severity::Warning
+                && finding
+                    .message
+                    .contains("outside the specification allowlist")
+        }));
+    }
+
+    #[test]
+    fn flags_a_signed_manifest_missing_its_subject_and_issued_at() {
+        let report = analyze(
+            r#"{
+              "specVersion": "1.0",
+              "entries": [
+                {
+                  "identifier": "urn:example:bare",
+                  "type": "application/json",
+                  "url": "https://example.com/a.json",
+                  "trustManifest": {
+                    "identity": "urn:example:bare",
+                    "signature": "eyJhbGciOiJFUzI1NiJ9..c2ln"
+                  }
+                }
+              ]
+            }"#,
+        );
+
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| { finding.message.contains("must carry a subject") })
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| { finding.message.contains("must carry an issuedAt") })
+        );
+    }
 
     #[test]
     fn parses_and_verifies_supported_digests() {
@@ -446,10 +961,10 @@ mod tests {
 				  "url": "https://example.com/agent.json",
 				  "trustManifest": {
 					"identity": "urn:example:agent",
-					"signature": "header..signature",
-					"metadata": {
-					  "zeta": true,
-					  "alpha": 1
+					"signature": "eyJhbGciOiJFUzI1NiJ9..c2ln",
+					"extensions": {
+					  "com.example.zeta": true,
+					  "com.example.alpha": 1
 					}
 				  }
 				}
@@ -465,7 +980,7 @@ mod tests {
             canonicalize_trust_manifest(manifest).expect("canonicalization should work");
 
         assert!(!canonical.contains("signature"));
-        assert!(canonical.contains("\"alpha\":1"));
+        assert!(canonical.contains("\"com.example.alpha\":1"));
         assert!(canonical.find("alpha").expect("alpha") < canonical.find("zeta").expect("zeta"));
     }
 
@@ -636,7 +1151,12 @@ mod tests {
 				"identifier": "did:web:example.com",
 				"trustManifest": {
 				  "identity": "did:web:example.com",
-				  "signature": "header..signature"
+				  "issuedAt": "2026-01-01T00:00:00Z",
+				  "signature": "eyJhbGciOiJFUzI1NiJ9..c2ln",
+				  "subject": {
+					"type": "application/ai-catalog+json",
+					"digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+				  }
 				}
 			  },
 			  "entries": [
@@ -647,7 +1167,13 @@ mod tests {
 				  "url": "https://example.com/artifact.json",
 				  "trustManifest": {
 					"identity": "urn:example:artifact",
-					"signature": "header..signature",
+					"issuedAt": "2026-01-01T00:00:00Z",
+					"signature": "eyJhbGciOiJFUzI1NiJ9..c2ln",
+					"subject": {
+					  "type": "application/json",
+					  "digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+					  "url": "https://example.com/artifact.json"
+					},
 					"trustSchema": {
 					  "identifier": "urn:trust:example",
 					  "version": "1.0"
@@ -682,6 +1208,10 @@ mod tests {
 
     fn parse_catalog(document: &str) -> ai_catalog::AiCatalog {
         parse_str(document).expect("catalog should parse")
+    }
+
+    fn analyze(document: &str) -> CatalogTrustReport {
+        analyze_catalog(&parse_catalog(document))
     }
 
     fn contains_finding(report: &CatalogTrustReport, severity: Severity, message: &str) -> bool {

--- a/crates/ai-catalog-validate/Cargo.toml
+++ b/crates/ai-catalog-validate/Cargo.toml
@@ -15,5 +15,6 @@ rust-version.workspace = true
 
 [dependencies]
 ai-catalog.workspace = true
+regex.workspace = true
 serde_json.workspace = true
 time.workspace = true

--- a/crates/ai-catalog-validate/README.md
+++ b/crates/ai-catalog-validate/README.md
@@ -1,19 +1,22 @@
 # ai-catalog-validate
 
 Semantic validation and conformance-level detection for
-[AI Catalog](https://agent-card.github.io/ai-catalog/) documents.
+[AI Catalog](https://ai-catalog.io/) documents.
 
 Checks the rules a JSON schema cannot express — duplicate identifiers, timestamp formats,
-nesting depth, and trust-manifest identity binding — and reports the conformance level a
-document reaches.
+nesting depth, extension key namespacing, and trust-manifest identity and subject binding —
+and reports the conformance level a document reaches.
 
 ## Conformance levels
 
 | Level | Requirements |
 |---|---|
-| Minimal | `specVersion` plus at least one entry with `identifier` and `type` |
-| Discoverable | Minimal, plus `url` or `data` and `tags` on each entry |
-| Trusted | Discoverable, plus a `trustManifest` with `identity` on each entry |
+| Minimal | `specVersion`, and every entry carrying `identifier`, `type`, and exactly one of `url` or `data` |
+| Discoverable | Minimal, plus a `host` object identifying the catalog operator |
+| Trusted | Discoverable, plus every `trustManifest` in the document signed, with a `subject` and `issuedAt` |
+
+A single unsigned manifest downgrades the whole document below Trusted, because a consumer
+cannot rely on trust it has no way to verify.
 
 ## Usage
 

--- a/crates/ai-catalog-validate/src/lib.rs
+++ b/crates/ai-catalog-validate/src/lib.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, HashMap};
+use std::sync::LazyLock;
 
 use ai_catalog::{
-    AiCatalog, CatalogEntry, identity_binds_to_entry, identity_domain, publisher_domain,
+    AiCatalog, Attestation, CatalogEntry, HostInfo, ProvenanceLink, Publisher, Subject,
+    TrustManifest, TrustSchema, identity_binds_to_entry, identity_domain, publisher_domain,
 };
+use regex::Regex;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
@@ -57,20 +60,34 @@ fn detect_level(catalog: &AiCatalog, errors: &[Diagnostic]) -> ConformanceLevel 
         return ConformanceLevel::Minimal;
     }
 
-    if catalog
-        .host
-        .as_ref()
-        .and_then(|host| host.trust_manifest.as_ref())
-        .is_some()
-        || catalog
-            .entries
-            .iter()
-            .any(|entry| entry.trust_manifest.is_some())
-    {
+    if is_trusted(catalog) {
         ConformanceLevel::Trusted
     } else {
         ConformanceLevel::Discoverable
     }
+}
+
+fn is_trusted(catalog: &AiCatalog) -> bool {
+    let manifests = catalog
+        .host
+        .as_ref()
+        .and_then(|host| host.trust_manifest.as_ref())
+        .into_iter()
+        .chain(
+            catalog
+                .entries
+                .iter()
+                .filter_map(|entry| entry.trust_manifest.as_ref()),
+        )
+        .collect::<Vec<_>>();
+
+    if manifests.is_empty() {
+        return false;
+    }
+
+    manifests.iter().all(|manifest| {
+        manifest.signature.is_some() && manifest.subject.is_some() && manifest.issued_at.is_some()
+    })
 }
 
 fn validate_catalog(
@@ -85,9 +102,13 @@ fn validate_catalog(
         &format!("{path}.specVersion"),
         errors,
     );
-    validate_metadata_keys(
-        catalog.metadata.as_ref(),
-        &format!("{path}.metadata"),
+    if let Some(host) = &catalog.host {
+        validate_host(host, &format!("{path}.host"), errors, warnings);
+    }
+
+    validate_extension_keys(
+        catalog.extensions.as_ref(),
+        &format!("{path}.extensions"),
         errors,
     );
 
@@ -159,6 +180,14 @@ fn validate_entry(
     errors: &mut Vec<Diagnostic>,
     warnings: &mut Vec<Diagnostic>,
 ) {
+    require_member(
+        &entry.identifier,
+        &format!("{path}.identifier"),
+        "identifier",
+        errors,
+    );
+    require_member(&entry.entry_type, &format!("{path}.type"), "type", errors);
+
     let has_url = entry.url.is_some();
     let has_data = entry.data.is_some();
 
@@ -186,14 +215,21 @@ fn validate_entry(
         );
     }
 
-    validate_metadata_keys(entry.metadata.as_ref(), &format!("{path}.metadata"), errors);
+    validate_extension_keys(
+        entry.extensions.as_ref(),
+        &format!("{path}.extensions"),
+        errors,
+    );
+
+    if let Some(publisher) = &entry.publisher {
+        validate_publisher(publisher, &format!("{path}.publisher"), errors);
+    }
 
     if let Some(trust_manifest) = &entry.trust_manifest {
-        validate_metadata_keys(
-            trust_manifest.metadata.as_ref(),
-            &format!("{path}.trustManifest.metadata"),
-            errors,
-        );
+        let manifest_path = format!("{path}.trustManifest");
+
+        validate_trust_manifest(trust_manifest, &manifest_path, errors, warnings);
+        validate_subject_binding(entry, trust_manifest, &manifest_path, errors);
 
         if identity_binds_to_entry(&entry.identifier, &trust_manifest.identity) == Some(false) {
             let publisher = publisher_domain(&entry.identifier).unwrap_or_default();
@@ -244,21 +280,316 @@ fn validate_entry(
     }
 }
 
-fn validate_metadata_keys(
-    metadata: Option<&BTreeMap<String, serde_json::Value>>,
+static REVERSE_DNS_KEY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+$",
+    )
+    .expect("reverse-DNS pattern is valid")
+});
+
+static URL_KEY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[A-Za-z][A-Za-z0-9+.\-]*://[^/?#\s]+").expect("URL pattern is valid")
+});
+
+fn is_extension_key(key: &str) -> bool {
+    URL_KEY.is_match(key) || REVERSE_DNS_KEY.is_match(key)
+}
+
+fn validate_extension_keys(
+    extensions: Option<&BTreeMap<String, serde_json::Value>>,
     path: &str,
     errors: &mut Vec<Diagnostic>,
 ) {
-    if let Some(metadata) = metadata {
-        for key in metadata.keys() {
-            if key.is_empty() {
-                push_error(
-                    errors,
-                    path.to_owned(),
-                    "metadata keys must be non-empty strings".to_owned(),
-                );
+    let Some(extensions) = extensions else {
+        return;
+    };
+
+    for key in extensions.keys() {
+        if !is_extension_key(key) {
+            push_error(
+                errors,
+                path.to_owned(),
+                format!("extension key '{key}' must be a valid URL or a reverse-DNS string"),
+            );
+        }
+    }
+}
+
+fn require_member(value: &str, path: &str, member: &str, errors: &mut Vec<Diagnostic>) {
+    if value.is_empty() {
+        push_error(
+            errors,
+            path.to_owned(),
+            format!("{member} is required and must not be empty"),
+        );
+    }
+}
+
+fn validate_publisher(publisher: &Publisher, path: &str, errors: &mut Vec<Diagnostic>) {
+    require_member(
+        &publisher.identifier,
+        &format!("{path}.identifier"),
+        "publisher.identifier",
+        errors,
+    );
+    require_member(
+        &publisher.display_name,
+        &format!("{path}.displayName"),
+        "publisher.displayName",
+        errors,
+    );
+}
+
+fn validate_trust_schema(schema: &TrustSchema, path: &str, errors: &mut Vec<Diagnostic>) {
+    require_member(
+        &schema.identifier,
+        &format!("{path}.identifier"),
+        "trustSchema.identifier",
+        errors,
+    );
+    require_member(
+        &schema.version,
+        &format!("{path}.version"),
+        "trustSchema.version",
+        errors,
+    );
+}
+
+fn validate_attestation(attestation: &Attestation, path: &str, errors: &mut Vec<Diagnostic>) {
+    require_member(
+        &attestation.r#type,
+        &format!("{path}.type"),
+        "attestation.type",
+        errors,
+    );
+    require_member(
+        &attestation.uri,
+        &format!("{path}.uri"),
+        "attestation.uri",
+        errors,
+    );
+}
+
+fn validate_provenance_link(link: &ProvenanceLink, path: &str, errors: &mut Vec<Diagnostic>) {
+    require_member(
+        &link.relation,
+        &format!("{path}.relation"),
+        "provenance.relation",
+        errors,
+    );
+    require_member(
+        &link.source_id,
+        &format!("{path}.sourceId"),
+        "provenance.sourceId",
+        errors,
+    );
+}
+
+fn validate_host(
+    host: &HostInfo,
+    path: &str,
+    errors: &mut Vec<Diagnostic>,
+    warnings: &mut Vec<Diagnostic>,
+) {
+    require_member(
+        &host.display_name,
+        &format!("{path}.displayName"),
+        "host.displayName",
+        errors,
+    );
+
+    if let Some(manifest) = &host.trust_manifest {
+        validate_trust_manifest(manifest, &format!("{path}.trustManifest"), errors, warnings);
+    }
+}
+
+fn validate_trust_manifest(
+    manifest: &TrustManifest,
+    path: &str,
+    errors: &mut Vec<Diagnostic>,
+    warnings: &mut Vec<Diagnostic>,
+) {
+    validate_extension_keys(
+        manifest.extensions.as_ref(),
+        &format!("{path}.extensions"),
+        errors,
+    );
+
+    require_member(
+        &manifest.identity,
+        &format!("{path}.identity"),
+        "trustManifest.identity",
+        errors,
+    );
+
+    if let Some(schema) = &manifest.trust_schema {
+        validate_trust_schema(schema, &format!("{path}.trustSchema"), errors);
+    }
+
+    for (index, attestation) in manifest.attestations.iter().enumerate() {
+        validate_attestation(
+            attestation,
+            &format!("{path}.attestations[{index}]"),
+            errors,
+        );
+    }
+
+    for (index, link) in manifest.provenance.iter().enumerate() {
+        validate_provenance_link(link, &format!("{path}.provenance[{index}]"), errors);
+    }
+
+    if !is_substantive(manifest) {
+        push_error(
+            errors,
+            path.to_owned(),
+            "trustManifest must carry at least one substantive member (a signature with its \
+             subject and issuedAt, a non-empty attestations or provenance array, or a \
+             trustSchema) and must otherwise be omitted entirely"
+                .to_owned(),
+        );
+    }
+
+    validate_signed_manifest_members(manifest, path, errors);
+    validate_manifest_timestamps(manifest, path, errors, warnings);
+    validate_subject(
+        manifest.subject.as_ref(),
+        &format!("{path}.subject"),
+        errors,
+    );
+}
+
+fn is_substantive(manifest: &TrustManifest) -> bool {
+    let signed =
+        manifest.signature.is_some() && manifest.subject.is_some() && manifest.issued_at.is_some();
+
+    signed
+        || !manifest.attestations.is_empty()
+        || !manifest.provenance.is_empty()
+        || manifest.trust_schema.is_some()
+}
+
+fn validate_signed_manifest_members(
+    manifest: &TrustManifest,
+    path: &str,
+    errors: &mut Vec<Diagnostic>,
+) {
+    if manifest.signature.is_none() {
+        return;
+    }
+
+    if manifest.subject.is_none() {
+        push_error(
+            errors,
+            format!("{path}.subject"),
+            "a trustManifest carrying a signature must include a subject".to_owned(),
+        );
+    }
+
+    if manifest.issued_at.is_none() {
+        push_error(
+            errors,
+            format!("{path}.issuedAt"),
+            "a trustManifest carrying a signature must include issuedAt".to_owned(),
+        );
+    }
+}
+
+fn validate_manifest_timestamps(
+    manifest: &TrustManifest,
+    path: &str,
+    errors: &mut Vec<Diagnostic>,
+    warnings: &mut Vec<Diagnostic>,
+) {
+    if let Some(issued_at) = &manifest.issued_at
+        && OffsetDateTime::parse(issued_at, &Rfc3339).is_err()
+    {
+        push_error(
+            errors,
+            format!("{path}.issuedAt"),
+            format!("issuedAt is not a valid RFC 3339 datetime: '{issued_at}'"),
+        );
+    }
+
+    let Some(expires_at) = &manifest.expires_at else {
+        return;
+    };
+
+    match OffsetDateTime::parse(expires_at, &Rfc3339) {
+        Ok(parsed) => {
+            if parsed < OffsetDateTime::now_utc() {
+                warnings.push(Diagnostic {
+                    path: format!("{path}.expiresAt"),
+                    message: format!(
+                        "trustManifest expired at '{expires_at}' and SHOULD be rejected"
+                    ),
+                });
             }
         }
+        Err(_) => push_error(
+            errors,
+            format!("{path}.expiresAt"),
+            format!("expiresAt is not a valid RFC 3339 datetime: '{expires_at}'"),
+        ),
+    }
+}
+
+fn validate_subject(subject: Option<&Subject>, path: &str, errors: &mut Vec<Diagnostic>) {
+    let Some(subject) = subject else {
+        return;
+    };
+
+    if subject.r#type.is_empty() {
+        push_error(
+            errors,
+            format!("{path}.type"),
+            "subject.type is required and must not be empty".to_owned(),
+        );
+    }
+
+    if subject.digest.is_empty() {
+        push_error(
+            errors,
+            format!("{path}.digest"),
+            "subject.digest is required and must not be empty".to_owned(),
+        );
+    }
+}
+
+fn validate_subject_binding(
+    entry: &CatalogEntry,
+    manifest: &TrustManifest,
+    path: &str,
+    errors: &mut Vec<Diagnostic>,
+) {
+    let Some(subject) = &manifest.subject else {
+        return;
+    };
+
+    if !subject.r#type.is_empty()
+        && !entry.entry_type.is_empty()
+        && subject.r#type != entry.entry_type
+    {
+        push_error(
+            errors,
+            format!("{path}.subject.type"),
+            format!(
+                "subject.type '{}' must equal the entry type '{}'",
+                subject.r#type, entry.entry_type
+            ),
+        );
+    }
+
+    if let Some(subject_url) = &subject.url
+        && Some(subject_url) != entry.url.as_ref()
+    {
+        push_error(
+            errors,
+            format!("{path}.subject.url"),
+            format!(
+                "subject.url '{subject_url}' must equal the entry url '{}'",
+                entry.url.as_deref().unwrap_or_default()
+            ),
+        );
     }
 }
 
@@ -474,7 +805,11 @@ mod tests {
                   "type": "application/json",
                   "url": "https://acme.com/test.json",
                   "trustManifest": {
-                    "identity": "did:web:acme.com"
+                    "identity": "did:web:acme.com",
+                    "trustSchema": {
+                      "identifier": "urn:example:schema",
+                      "version": "1.0"
+                    }
                   }
                 }
               ]
@@ -484,7 +819,255 @@ mod tests {
 
         let result = validate(&catalog);
 
-        assert!(result.is_valid);
+        assert!(result.is_valid, "unexpected errors: {:?}", result.errors);
+    }
+
+    #[test]
+    fn rejects_trust_manifest_without_substantive_members() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "entries": [
+                {
+                    "identifier": "urn:example:bare",
+                    "displayName": "Bare",
+                    "type": "application/json",
+                    "url": "https://example.com/bare.json",
+                    "trustManifest": {
+                        "identity": "urn:example:bare"
+                    }
+                }
+            ]
+        }));
+
+        assert!(!result.is_valid);
+        assert!(result.errors.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("must carry at least one substantive member")
+        }));
+    }
+
+    #[test]
+    fn requires_subject_and_issued_at_alongside_a_signature() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "entries": [
+                {
+                    "identifier": "urn:example:signed",
+                    "displayName": "Signed",
+                    "type": "application/json",
+                    "url": "https://example.com/signed.json",
+                    "trustManifest": {
+                        "identity": "urn:example:signed",
+                        "signature": "eyJhbGciOiJFUzI1NiJ9..c2ln"
+                    }
+                }
+            ]
+        }));
+
+        assert!(!result.is_valid);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|diagnostic| { diagnostic.message.contains("must include a subject") })
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|diagnostic| { diagnostic.message.contains("must include issuedAt") })
+        );
+    }
+
+    #[test]
+    fn rejects_subject_that_does_not_restate_the_entry() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "entries": [
+                {
+                    "identifier": "urn:example:bound",
+                    "displayName": "Bound",
+                    "type": "application/json",
+                    "url": "https://example.com/bound.json",
+                    "trustManifest": {
+                        "identity": "urn:example:bound",
+                        "issuedAt": "2026-01-01T00:00:00Z",
+                        "signature": "eyJhbGciOiJFUzI1NiJ9..c2ln",
+                        "subject": {
+                            "type": "application/gguf",
+                            "digest": "sha256:abc",
+                            "url": "https://example.com/other.json"
+                        }
+                    }
+                }
+            ]
+        }));
+
+        assert!(!result.is_valid);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|diagnostic| { diagnostic.message.contains("must equal the entry type") })
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|diagnostic| { diagnostic.message.contains("must equal the entry url") })
+        );
+    }
+
+    #[test]
+    fn diagnoses_every_missing_required_member() {
+        let cases: [(serde_json::Value, &str); 6] = [
+            (json!({"entries": []}), "specVersion must not be empty"),
+            (
+                json!({"specVersion": "1.0", "entries": [{"type": "application/json", "url": "https://e.com/a"}]}),
+                "identifier is required",
+            ),
+            (
+                json!({"specVersion": "1.0", "entries": [{"identifier": "urn:air:e.com:a:b", "url": "https://e.com/a"}]}),
+                "type is required",
+            ),
+            (
+                json!({"specVersion": "1.0", "entries": [{"identifier": "urn:air:e.com:a:b", "type": "application/json", "url": "https://e.com/a", "publisher": {"identifier": "did:web:e.com"}}]}),
+                "publisher.displayName is required",
+            ),
+            (
+                json!({"specVersion": "1.0", "entries": [{"identifier": "urn:air:e.com:a:b", "type": "application/json", "url": "https://e.com/a", "trustManifest": {"attestations": [{"type": "soc2"}]}}]}),
+                "attestation.uri is required",
+            ),
+            (
+                json!({"specVersion": "1.0", "entries": [{"identifier": "urn:air:e.com:a:b", "type": "application/json", "url": "https://e.com/a", "trustManifest": {"identity": "did:web:e.com", "provenance": [{"relation": "derivedFrom"}]}}]}),
+                "provenance.sourceId is required",
+            ),
+        ];
+
+        for (document, expected) in cases {
+            let result = validate_value(document.clone());
+
+            assert!(
+                result
+                    .errors
+                    .iter()
+                    .any(|diagnostic| diagnostic.message.contains(expected)),
+                "expected '{expected}' for {document}, got {:?}",
+                result.errors
+            );
+        }
+    }
+
+    #[test]
+    fn requires_trust_schema_identifier_and_version() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "entries": [
+                {
+                    "identifier": "urn:air:e.com:a:b",
+                    "type": "application/json",
+                    "url": "https://e.com/a",
+                    "trustManifest": {
+                        "identity": "did:web:e.com",
+                        "trustSchema": {}
+                    }
+                }
+            ]
+        }));
+
+        assert!(!result.is_valid);
+        assert!(result.errors.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("trustSchema.identifier is required")
+        }));
+        assert!(result.errors.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("trustSchema.version is required")
+        }));
+    }
+
+    #[test]
+    fn requires_publisher_identifier_and_display_name() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "entries": [
+                {
+                    "identifier": "urn:example:pub",
+                    "displayName": "Pub",
+                    "type": "application/json",
+                    "url": "https://example.com/pub.json",
+                    "publisher": {"identifier": "", "displayName": ""}
+                }
+            ]
+        }));
+
+        assert!(!result.is_valid);
+        assert!(result.errors.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("publisher.identifier is required")
+        }));
+        assert!(result.errors.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("publisher.displayName is required")
+        }));
+    }
+
+    #[test]
+    fn requires_host_display_name() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "host": {
+                "identifier": "did:web:example.com"
+            },
+            "entries": []
+        }));
+
+        assert!(!result.is_valid);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|diagnostic| { diagnostic.message.contains("host.displayName is required") })
+        );
+    }
+
+    #[test]
+    fn warns_on_expired_trust_manifest() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "entries": [
+                {
+                    "identifier": "urn:example:expired",
+                    "displayName": "Expired",
+                    "type": "application/json",
+                    "url": "https://example.com/expired.json",
+                    "trustManifest": {
+                        "identity": "urn:example:expired",
+                        "issuedAt": "2020-01-01T00:00:00Z",
+                        "expiresAt": "2020-06-01T00:00:00Z",
+                        "signature": "eyJhbGciOiJFUzI1NiJ9..c2ln",
+                        "subject": {
+                            "type": "application/json",
+                            "digest": "sha256:abc",
+                            "url": "https://example.com/expired.json"
+                        }
+                    }
+                }
+            ]
+        }));
+
+        assert!(result.is_valid, "unexpected errors: {:?}", result.errors);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|diagnostic| { diagnostic.message.contains("expired at") })
+        );
     }
 
     #[test]
@@ -506,7 +1089,7 @@ mod tests {
     }
 
     #[test]
-    fn classifies_valid_catalog_with_entry_trust_manifest_as_trusted() {
+    fn classifies_valid_catalog_with_signed_entry_manifest_as_trusted() {
         let result = validate_value(json!({
             "specVersion": "1.0",
             "host": {
@@ -519,7 +1102,14 @@ mod tests {
                     "type": "application/json",
                     "url": "https://example.com/trusted.json",
                     "trustManifest": {
-                        "identity": "urn:example:trusted"
+                        "identity": "urn:example:trusted",
+                        "issuedAt": "2026-01-01T00:00:00Z",
+                        "signature": "eyJhbGciOiJFUzI1NiJ9..c2ln",
+                        "subject": {
+                            "type": "application/json",
+                            "digest": "sha256:abc",
+                            "url": "https://example.com/trusted.json"
+                        }
                     }
                 }
             ]
@@ -527,6 +1117,34 @@ mod tests {
 
         assert!(result.is_valid, "unexpected errors: {:?}", result.errors);
         assert_eq!(result.conformance_level, ConformanceLevel::Trusted);
+    }
+
+    #[test]
+    fn an_unsigned_manifest_downgrades_the_catalog_below_trusted() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "host": {
+                "displayName": "Example Host"
+            },
+            "entries": [
+                {
+                    "identifier": "urn:example:unsigned",
+                    "displayName": "Unsigned",
+                    "type": "application/json",
+                    "url": "https://example.com/unsigned.json",
+                    "trustManifest": {
+                        "identity": "urn:example:unsigned",
+                        "trustSchema": {
+                            "identifier": "urn:example:schema",
+                            "version": "1.0"
+                        }
+                    }
+                }
+            ]
+        }));
+
+        assert!(result.is_valid, "unexpected errors: {:?}", result.errors);
+        assert_eq!(result.conformance_level, ConformanceLevel::Discoverable);
     }
 
     #[test]
@@ -638,26 +1256,21 @@ mod tests {
     }
 
     #[test]
-    fn rejects_empty_metadata_keys() {
+    fn rejects_unnamespaced_extension_keys() {
         let result = validate_value(json!({
             "specVersion": "1.0",
-            "metadata": {
-                "": true
+            "extensions": {
+                "": true,
+                "scope": "demo"
             },
             "entries": [
                 {
-                    "identifier": "urn:example:metadata",
-                    "displayName": "Metadata",
+                    "identifier": "urn:example:extensions",
+                    "displayName": "Extensions",
                     "type": "application/json",
-                    "url": "https://example.com/metadata.json",
-                    "metadata": {
-                        "": 1
-                    },
-                    "trustManifest": {
-                        "identity": "urn:example:metadata",
-                        "metadata": {
-                            "": "bad"
-                        }
+                    "url": "https://example.com/extensions.json",
+                    "extensions": {
+                        "notNamespaced": 1
                     }
                 }
             ]
@@ -670,10 +1283,31 @@ mod tests {
                 .iter()
                 .filter(|diagnostic| diagnostic
                     .message
-                    .contains("metadata keys must be non-empty strings"))
+                    .contains("must be a valid URL or a reverse-DNS string"))
                 .count(),
             3
         );
+    }
+
+    #[test]
+    fn accepts_url_and_reverse_dns_extension_keys() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "extensions": {
+                "com.example.confidenceScore": 0.9,
+                "https://example.com/ext": true
+            },
+            "entries": [
+                {
+                    "identifier": "urn:example:extensions",
+                    "displayName": "Extensions",
+                    "type": "application/json",
+                    "url": "https://example.com/extensions.json"
+                }
+            ]
+        }));
+
+        assert!(result.is_valid, "unexpected errors: {:?}", result.errors);
     }
 
     #[test]
@@ -748,7 +1382,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_invalid_nested_catalog_data() {
+    fn reports_the_violated_member_inside_nested_catalog_data() {
         let result = validate_value(json!({
             "specVersion": "1.0",
             "entries": [
@@ -764,11 +1398,43 @@ mod tests {
         }));
 
         assert!(!result.is_valid);
-        assert!(result.errors.iter().any(|diagnostic| {
-            diagnostic
-                .message
-                .contains("nested catalog data is not a valid AI Catalog")
+        assert!(
+            result.errors.iter().any(|diagnostic| {
+                diagnostic.path == "catalog.entries[0].data.specVersion"
+                    && diagnostic.message.contains("specVersion must not be empty")
+            }),
+            "unexpected errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn rejects_structurally_invalid_nested_catalog_data() {
+        let result = validate_value(json!({
+            "specVersion": "1.0",
+            "entries": [
+                {
+                    "identifier": "urn:example:bad-nested",
+                    "displayName": "Bad Nested",
+                    "type": "application/ai-catalog+json",
+                    "data": {
+                        "specVersion": "1.0",
+                        "entries": "not-an-array"
+                    }
+                }
+            ]
         }));
+
+        assert!(!result.is_valid);
+        assert!(
+            result.errors.iter().any(|diagnostic| {
+                diagnostic
+                    .message
+                    .contains("nested catalog data is not a valid AI Catalog")
+            }),
+            "unexpected errors: {:?}",
+            result.errors
+        );
     }
 
     #[test]

--- a/crates/ai-catalog/README.md
+++ b/crates/ai-catalog/README.md
@@ -1,6 +1,6 @@
 # ai-catalog
 
-Core types and JSON parsing for the [AI Catalog specification](https://agent-card.github.io/ai-catalog/).
+Core types and JSON parsing for the [AI Catalog specification](https://ai-catalog.io/).
 
 Provides `AiCatalog`, `CatalogEntry`, `HostInfo`, `Publisher`, `TrustManifest`, and the
 surrounding model types, along with helpers to parse and serialize catalog documents.

--- a/crates/ai-catalog/src/lib.rs
+++ b/crates/ai-catalog/src/lib.rs
@@ -8,8 +8,8 @@ mod model;
 pub use error::{Error, Result};
 pub use identity::{identity_binds_to_entry, identity_domain, publisher_domain};
 pub use model::{
-    AiCatalog, Attestation, CatalogEntry, HostInfo, ProvenanceLink, Publisher, TrustManifest,
-    TrustSchema,
+    AiCatalog, Attestation, CatalogEntry, HostInfo, ProvenanceLink, Publisher, Subject,
+    TrustManifest, TrustSchema,
 };
 
 use std::fs;
@@ -72,10 +72,7 @@ mod tests {
         assert_eq!(catalog.spec_version, "1.0");
         assert_eq!(catalog.entries.len(), 2);
         assert_eq!(
-            catalog
-                .host
-                .as_ref()
-                .and_then(|host| host.display_name.as_deref()),
+            catalog.host.as_ref().map(|host| host.display_name.as_str()),
             Some("Acme Services Inc."),
         );
 

--- a/crates/ai-catalog/src/model.rs
+++ b/crates/ai-catalog/src/model.rs
@@ -10,13 +10,16 @@ use serde_json::Value;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AiCatalog {
+    #[serde(default)]
     pub spec_version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host: Option<HostInfo>,
     #[serde(default)]
     pub entries: Vec<CatalogEntry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<BTreeMap<String, Value>>,
+    pub signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, Value>>,
     #[serde(flatten, default)]
     pub extra_fields: BTreeMap<String, Value>,
 }
@@ -76,8 +79,8 @@ impl AiCatalog {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HostInfo {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
+    #[serde(default)]
+    pub display_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -93,10 +96,11 @@ pub struct HostInfo {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogEntry {
+    #[serde(default)]
     pub identifier: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub entry_type: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -115,7 +119,7 @@ pub struct CatalogEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<BTreeMap<String, Value>>,
+    pub extensions: Option<BTreeMap<String, Value>>,
     #[serde(flatten, default)]
     pub extra_fields: BTreeMap<String, Value>,
 }
@@ -129,7 +133,9 @@ impl CatalogEntry {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Publisher {
+    #[serde(default)]
     pub identifier: String,
+    #[serde(default)]
     pub display_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity_type: Option<String>,
@@ -140,6 +146,7 @@ pub struct Publisher {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrustManifest {
+    #[serde(default)]
     pub identity: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity_type: Option<String>,
@@ -154,9 +161,28 @@ pub struct TrustManifest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub terms_of_service_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<Subject>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issued_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<BTreeMap<String, Value>>,
+    pub extensions: Option<BTreeMap<String, Value>>,
+    #[serde(flatten, default)]
+    pub extra_fields: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Subject {
+    #[serde(default)]
+    pub r#type: String,
+    #[serde(default)]
+    pub digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
     #[serde(flatten, default)]
     pub extra_fields: BTreeMap<String, Value>,
 }
@@ -164,7 +190,9 @@ pub struct TrustManifest {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrustSchema {
+    #[serde(default)]
     pub identifier: String,
+    #[serde(default)]
     pub version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub governance_uri: Option<String>,
@@ -177,7 +205,9 @@ pub struct TrustSchema {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Attestation {
+    #[serde(default)]
     pub r#type: String,
+    #[serde(default)]
     pub uri: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,
@@ -192,7 +222,9 @@ pub struct Attestation {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvenanceLink {
+    #[serde(default)]
     pub relation: String,
+    #[serde(default)]
     pub source_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_digest: Option<String>,


### PR DESCRIPTION
## Model

- `metadata` → `extensions` on `AiCatalog`, `CatalogEntry`, `TrustManifest`.
- Add `Subject`. `TrustManifest` gains `subject`, `issuedAt`, `expiresAt`, `signature`;
  `AiCatalog` gains `signature`.
- `HostInfo.displayName` required: `Option<String>` → `String`.
- Spec-required scalars parse leniently, so violations surface as validation
  diagnostics instead of serde errors.

## Validation

- Report every MUST-contain member across catalog, entry, publisher, host,
  manifest, trustSchema, attestation and provenance.
- Extension keys must be a URL or a reverse-DNS string.
- A signature requires `subject` and `issuedAt`; a subject must restate the
  entry's `type` and `url`.
- Reject empty trust manifests. Trusted requires every manifest signed.

## Trust

- Descend into catalogs nested in `entry.data`, depth limit 4. Previously only
  top-level manifests were analyzed.
- Analyze the document-level `signature`; add `CatalogTrustReport.has_signature`.
- Add `canonicalize_catalog`.
- JWS `alg` allowlist: ES256/ES384/EdDSA/PS256/PS384/RS256. Reject `none` and HMAC.
- Compare timestamps as RFC 3339 instants, not strings.
- Replace the hand-rolled key sort with `serde_jcs`.
