### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/agntcy/ai-catalog-rust"
 rust-version = "1.95"
-version = "0.1.0"
+version = "0.2.0"
 
 [workspace.dependencies]
-ai-catalog = { path = "crates/ai-catalog", version = "0.1.0" }
-ai-catalog-oci = { path = "crates/ai-catalog-oci", version = "0.1.0" }
-ai-catalog-trust = { path = "crates/ai-catalog-trust", version = "0.1.0" }
-ai-catalog-validate = { path = "crates/ai-catalog-validate", version = "0.1.0" }
+ai-catalog = { path = "crates/ai-catalog", version = "0.2.0" }
+ai-catalog-oci = { path = "crates/ai-catalog-oci", version = "0.2.0" }
+ai-catalog-trust = { path = "crates/ai-catalog-trust", version = "0.2.0" }
+ai-catalog-validate = { path = "crates/ai-catalog-validate", version = "0.2.0" }
 base64 = "0.22"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/ai-catalog-oci/CHANGELOG.md
+++ b/crates/ai-catalog-oci/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/ai-catalog-rust/compare/ai-catalog-oci-v0.1.0...ai-catalog-oci-v0.2.0) - 2026-08-13
+
+### Added
+
+- align model, validation, and trust analysis with the AI Catalog specification ([#14](https://github.com/agntcy/ai-catalog-rust/pull/14))
+
 ## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-oci-v0.1.0) - 2026-08-04
 
 ### Added

--- a/crates/ai-catalog-trust/CHANGELOG.md
+++ b/crates/ai-catalog-trust/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/ai-catalog-rust/compare/ai-catalog-trust-v0.1.0...ai-catalog-trust-v0.2.0) - 2026-08-13
+
+### Added
+
+- align model, validation, and trust analysis with the AI Catalog specification ([#14](https://github.com/agntcy/ai-catalog-rust/pull/14))
+
 ## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-trust-v0.1.0) - 2026-08-04
 
 ### Added

--- a/crates/ai-catalog-validate/CHANGELOG.md
+++ b/crates/ai-catalog-validate/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/ai-catalog-rust/compare/ai-catalog-validate-v0.1.0...ai-catalog-validate-v0.2.0) - 2026-08-13
+
+### Added
+
+- align model, validation, and trust analysis with the AI Catalog specification ([#14](https://github.com/agntcy/ai-catalog-rust/pull/14))
+
 ## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-validate-v0.1.0) - 2026-08-04
 
 ### Added

--- a/crates/ai-catalog/CHANGELOG.md
+++ b/crates/ai-catalog/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/agntcy/ai-catalog-rust/compare/ai-catalog-v0.1.0...ai-catalog-v0.2.0) - 2026-08-13
+
+### Added
+
+- align model, validation, and trust analysis with the AI Catalog specification ([#14](https://github.com/agntcy/ai-catalog-rust/pull/14))
+
 ## [0.1.0](https://github.com/agntcy/ai-catalog-rust/releases/tag/ai-catalog-v0.1.0) - 2026-08-04
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `ai-catalog`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `ai-catalog-validate`: 0.1.0 -> 0.2.0 (✓ API compatible changes)
* `ai-catalog-trust`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `ai-catalog-oci`: 0.1.0 -> 0.2.0 (✓ API compatible changes)

### ⚠ `ai-catalog` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CatalogEntry.extensions in /tmp/.tmpq7GEgP/ai-catalog-rust/crates/ai-catalog/src/model.rs:122
  field TrustManifest.subject in /tmp/.tmpq7GEgP/ai-catalog-rust/crates/ai-catalog/src/model.rs:164
  field TrustManifest.issued_at in /tmp/.tmpq7GEgP/ai-catalog-rust/crates/ai-catalog/src/model.rs:166
  field TrustManifest.expires_at in /tmp/.tmpq7GEgP/ai-catalog-rust/crates/ai-catalog/src/model.rs:168
  field TrustManifest.extensions in /tmp/.tmpq7GEgP/ai-catalog-rust/crates/ai-catalog/src/model.rs:172
  field AiCatalog.signature in /tmp/.tmpq7GEgP/ai-catalog-rust/crates/ai-catalog/src/model.rs:20
  field AiCatalog.extensions in /tmp/.tmpq7GEgP/ai-catalog-rust/crates/ai-catalog/src/model.rs:22

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field metadata of struct CatalogEntry, previously in file /tmp/.tmpG45WZ4/ai-catalog/src/model.rs:118
  field metadata of struct TrustManifest, previously in file /tmp/.tmpG45WZ4/ai-catalog/src/model.rs:159
  field metadata of struct AiCatalog, previously in file /tmp/.tmpG45WZ4/ai-catalog/src/model.rs:19
```

### ⚠ `ai-catalog-trust` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CatalogTrustReport.has_signature in /tmp/.tmpq7GEgP/ai-catalog-rust/crates/ai-catalog-trust/src/lib.rs:60
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `ai-catalog`

<blockquote>

## [0.2.0](https://github.com/agntcy/ai-catalog-rust/compare/ai-catalog-v0.1.0...ai-catalog-v0.2.0) - 2026-08-13

### Added

- align model, validation, and trust analysis with the AI Catalog specification ([#14](https://github.com/agntcy/ai-catalog-rust/pull/14))
</blockquote>

## `ai-catalog-validate`

<blockquote>

## [0.2.0](https://github.com/agntcy/ai-catalog-rust/compare/ai-catalog-validate-v0.1.0...ai-catalog-validate-v0.2.0) - 2026-08-13

### Added

- align model, validation, and trust analysis with the AI Catalog specification ([#14](https://github.com/agntcy/ai-catalog-rust/pull/14))
</blockquote>

## `ai-catalog-trust`

<blockquote>

## [0.2.0](https://github.com/agntcy/ai-catalog-rust/compare/ai-catalog-trust-v0.1.0...ai-catalog-trust-v0.2.0) - 2026-08-13

### Added

- align model, validation, and trust analysis with the AI Catalog specification ([#14](https://github.com/agntcy/ai-catalog-rust/pull/14))
</blockquote>

## `ai-catalog-oci`

<blockquote>

## [0.2.0](https://github.com/agntcy/ai-catalog-rust/compare/ai-catalog-oci-v0.1.0...ai-catalog-oci-v0.2.0) - 2026-08-13

### Added

- align model, validation, and trust analysis with the AI Catalog specification ([#14](https://github.com/agntcy/ai-catalog-rust/pull/14))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).