### PR TITLE
chore: remove AGNTCY references, migrate to trusted publishing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 # Default ownership for the repository.
-* @agntcy/rustaceans @agntcy/sdk-admins
+* @Agent-Card/rustaceans @Agent-Card/sdk-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default ownership for the repository.
-* @Agent-Card/rustaceans @Agent-Card/sdk-admins
+* @Agent-Card/sdk-rust

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 # Default ownership for the repository.

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -6,21 +6,21 @@ name: Setup Environment
 description: setup environment to build/test/lint rust applications
 inputs:
   workspace:
-    description: 'Cargo workspace to cache'
+    description: "Cargo workspace to cache"
     required: false
-    default: '.'
+    default: "."
   cache-enabled:
-    description: 'Enable rust cache'
+    description: "Enable rust cache"
     required: false
-    default: 'true'
+    default: "true"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Setup Rust
-      uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         components: rustc, clippy, rustfmt
-        rustflags: ''
+        rustflags: ""
         cache: ${{ inputs.cache-enabled }}
         cache-workspaces: ${{ inputs.workspace }}
         cache-on-failure: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -31,7 +31,7 @@ jobs:
         uses: taiki-e/install-action@6155d2cb312b464292646e69dce00eee78f23151
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Build
         run: just build
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -62,7 +62,7 @@ jobs:
         uses: taiki-e/install-action@e5de28abeb52d916c5e5875d54b21a9e738b61ec
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Run coverage
         run: |
@@ -75,7 +75,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage summary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-summary
           path: coverage-summary.txt

--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright Agent-Card Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 ---
@@ -23,7 +23,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          token: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
       - name: Run release-plz
@@ -33,7 +32,6 @@ jobs:
           manifest_path: ./Cargo.toml
           config: ./.release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-crates-pr:
@@ -61,5 +59,4 @@ jobs:
           manifest_path: ./Cargo.toml
           config: ./.release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.AGNTCY_BUILD_BOT_GH_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -20,14 +20,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
       - name: Run release-plz
-        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release
           manifest_path: ./Cargo.toml
@@ -45,14 +45,14 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
       - name: Run release-plz - PR
-        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release-pr
           manifest_path: ./Cargo.toml

--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -1,4 +1,4 @@
-# Copyright Agent-Card Contributors (https://github.com/Agent-Card)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 ---
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,8 +32,6 @@ jobs:
           command: release
           manifest_path: ./Cargo.toml
           config: ./.release-plz.toml
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-crates-pr:
     name: Release catalog crates - PR
@@ -58,5 +57,3 @@ jobs:
           command: release-pr
           manifest_path: ./Cargo.toml
           config: ./.release-plz.toml
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 [workspace]

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 [workspace]
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/agntcy/ai-catalog-rust"
+repository = "https://github.com/Agent-Card/ai-catalog-rust"
 rust-version = "1.95"
 version = "0.2.0"
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Governance
 
-This repository is maintained by AGNTCY Contributors.
+This repository is maintained by AI-Catalog Contributors.
 
 ## Decision Making
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Rust libraries for the [AI Catalog specification](https://ai-catalog.io/).
 |---|---|
 | Specification | <https://ai-catalog.io/> |
 | Upstream repository | <https://github.com/Agent-Card/ai-catalog> |
-| Command-line tool | <https://github.com/agntcy/ai-catalog-cli> |
+| Command-line tool | <https://github.com/Agent-Card/ai-catalog-cli> |
 
 ## Workspace
 
@@ -22,7 +22,7 @@ specification. `ai-catalog-oci` is a convenience for distributing catalogs over
 existing registry infrastructure; OCI packaging is not part of the spec.
 
 The `ai-catalog` command-line tool lives in
-[`agntcy/ai-catalog-cli`](https://github.com/agntcy/ai-catalog-cli) and consumes
+[`Agent-Card/ai-catalog-cli`](https://github.com/Agent-Card/ai-catalog-cli) and consumes
 these crates from crates.io.
 
 ### Conformance levels

--- a/crates/ai-catalog-oci/Cargo.toml
+++ b/crates/ai-catalog-oci/Cargo.toml
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/crates/ai-catalog-oci/Cargo.toml
+++ b/crates/ai-catalog-oci/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/crates/ai-catalog-oci/src/lib.rs
+++ b/crates/ai-catalog-oci/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/ai-catalog-oci/src/lib.rs
+++ b/crates/ai-catalog-oci/src/lib.rs
@@ -1,4 +1,5 @@
-// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/ai-catalog-trust/Cargo.toml
+++ b/crates/ai-catalog-trust/Cargo.toml
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/crates/ai-catalog-trust/Cargo.toml
+++ b/crates/ai-catalog-trust/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/crates/ai-catalog-trust/src/lib.rs
+++ b/crates/ai-catalog-trust/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 // SPDX-License-Identifier: Apache-2.0
 
 use ai_catalog::{

--- a/crates/ai-catalog-trust/src/lib.rs
+++ b/crates/ai-catalog-trust/src/lib.rs
@@ -1,4 +1,5 @@
-// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
 use ai_catalog::{

--- a/crates/ai-catalog-validate/Cargo.toml
+++ b/crates/ai-catalog-validate/Cargo.toml
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/crates/ai-catalog-validate/Cargo.toml
+++ b/crates/ai-catalog-validate/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/crates/ai-catalog-validate/src/lib.rs
+++ b/crates/ai-catalog-validate/src/lib.rs
@@ -1,4 +1,5 @@
-// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, HashMap};

--- a/crates/ai-catalog-validate/src/lib.rs
+++ b/crates/ai-catalog-validate/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, HashMap};

--- a/crates/ai-catalog/Cargo.toml
+++ b/crates/ai-catalog/Cargo.toml
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/crates/ai-catalog/Cargo.toml
+++ b/crates/ai-catalog/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/crates/ai-catalog/src/error.rs
+++ b/crates/ai-catalog/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 // SPDX-License-Identifier: Apache-2.0
 
 use thiserror::Error;

--- a/crates/ai-catalog/src/error.rs
+++ b/crates/ai-catalog/src/error.rs
@@ -1,4 +1,5 @@
-// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
 use thiserror::Error;

--- a/crates/ai-catalog/src/identity.rs
+++ b/crates/ai-catalog/src/identity.rs
@@ -1,4 +1,4 @@
-// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 // SPDX-License-Identifier: Apache-2.0
 
 const URN_AIR_PREFIX: &str = "urn:air:";

--- a/crates/ai-catalog/src/identity.rs
+++ b/crates/ai-catalog/src/identity.rs
@@ -1,4 +1,5 @@
-// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
 const URN_AIR_PREFIX: &str = "urn:air:";

--- a/crates/ai-catalog/src/lib.rs
+++ b/crates/ai-catalog/src/lib.rs
@@ -1,4 +1,5 @@
-// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
 mod error;

--- a/crates/ai-catalog/src/lib.rs
+++ b/crates/ai-catalog/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 // SPDX-License-Identifier: Apache-2.0
 
 mod error;

--- a/crates/ai-catalog/src/model.rs
+++ b/crates/ai-catalog/src/model.rs
@@ -1,4 +1,4 @@
-// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;

--- a/crates/ai-catalog/src/model.rs
+++ b/crates/ai-catalog/src/model.rs
@@ -1,4 +1,5 @@
-// Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+// Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 default:

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 default:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
-# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
 # SPDX-License-Identifier: Apache-2.0
 
 [toolchain]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
-# Copyright AI-Catalog Contributors (https://github.com/Agent-Card)
+# Copyright AI-Catalog Contributors (https://github.com/Agent-Card/ai-catalog-rust)
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
 [toolchain]


### PR DESCRIPTION
Renames all AGNTCY-branded references (copyright headers, GOVERNANCE.md, README links, repository URLs) to Agent-Card across the workspace and its crates (ai-catalog, ai-catalog-oci, ai-catalog-trust, ai-catalog-validate).

- Copyright headers and repository fields updated from github.com/agntcy/* to github.com/Agent-Card/*
- README and GOVERNANCE.md prose updated to reference Agent-Card instead of AGNTCY
- release-rust.yaml: switched crates.io publishing to OIDC trusted publishing, dropped AGNTCY_BUILD_BOT_GH_TOKEN and CARGO_REGISTRY_TOKEN secrets, added id-token: write permission
- Bumped actions/checkout (v6.0.2 → v7.0.1) and release-plz/action (v0.5.128 → v0.5.131)
- CODEOWNERS and other CI/config files updated for the new org